### PR TITLE
Keep adding extra device-ids on eviction

### DIFF
--- a/sdp-device-id-service/src/device_id_manager.rs
+++ b/sdp-device-id-service/src/device_id_manager.rs
@@ -142,7 +142,7 @@ impl DeviceIdAPI for KubeDeviceIdManager {
                                     service_identity.metadata.uid.clone().unwrap_or_default();
 
                                 if let Some(num_replicas) = replicaset.spec.unwrap().replicas {
-                                    for _ in 0..(2 * num_replicas) {
+                                    for _ in 0..(5 * num_replicas) {
                                         let uuid = Uuid::new_v4().to_string();
                                         info!(
                                             "[{}] Assigning uuid {} to DeviceID {}",


### PR DESCRIPTION
This is a workaround for now, at some point we will implement a watcher (is this possible) to detect evicted pods.

Maybe the watcher we have now on pods is more than enough, something to try.