### PR TITLE
Release device-id on POD eviction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-common"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "chrono",
  "const_format",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-device-id-service"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "clap",
  "futures",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-identity-service"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "clap",
  "futures",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-injector"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "futures",
  "futures-util",
@@ -1561,11 +1561,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-macros"
-version = "1.0.1"
+version = "1.0.2"
 
 [[package]]
 name = "sdp-proc-macros"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-test-macros"
-version = "1.0.1"
+version = "1.0.2"
 
 [[package]]
 name = "secrecy"

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: "1.0.2"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.1"
+appVersion: "1.0.2"

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart to deploy CRDs for SDP Kubernetes Injector
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: 1.0.1
+version: "1.0.2"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
-appVersion: "1.0.1"
+appVersion: "1.0.2"

--- a/sdp-common/Cargo.toml
+++ b/sdp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-common"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-device-id-service/Cargo.toml
+++ b/sdp-device-id-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-device-id-service"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/Cargo.toml
+++ b/sdp-identity-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-identity-service"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-injector/Cargo.toml
+++ b/sdp-injector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-injector"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-injector/src/pod_watcher.rs
+++ b/sdp-injector/src/pod_watcher.rs
@@ -32,7 +32,7 @@ fn get_device_id(
                 Ok(uuid) => {
                     info!(
                         "[{}] Deleted POD with DeviceID assigned {}",
-                        service_id, &service_id
+                        service_id, &uuid.to_string()
                     );
                     Some(DeviceIdProviderRequestProtocol::ReleasedDeviceId(
                         service_id.clone(),

--- a/sdp-macros/Cargo.toml
+++ b/sdp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-macros"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-proc-macros/Cargo.toml
+++ b/sdp-proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-proc-macros"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-test-macros/Cargo.toml
+++ b/sdp-test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-test-macros"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
When we detect that a POD has been evicted we should release the device-id associated to it