### PR TITLE
Reuse existing client profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-common"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "chrono",
  "const_format",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-device-id-service"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "clap",
  "futures",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-identity-service"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "clap",
  "futures",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-injector"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "futures",
  "futures-util",
@@ -1561,11 +1561,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-macros"
-version = "1.0.3"
+version = "1.0.4"
 
 [[package]]
 name = "sdp-proc-macros"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-test-macros"
-version = "1.0.3"
+version = "1.0.4"
 
 [[package]]
 name = "secrecy"

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.0.3"
+version: "1.0.4"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.3"
+appVersion: "1.0.4"

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.0.3"
+version: "1.0.4"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
-appVersion: "1.0.3"
+appVersion: "1.0.4"

--- a/sdp-common/Cargo.toml
+++ b/sdp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-common"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-common/src/sdp/system.rs
+++ b/sdp-common/src/sdp/system.rs
@@ -103,7 +103,7 @@ impl SystemConfig {
 }
 
 /// struct representing a client profile
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ClientProfile {
     pub id: String,

--- a/sdp-common/src/service.rs
+++ b/sdp-common/src/service.rs
@@ -492,7 +492,7 @@ pub fn get_service_username(cluster_name: &str, service_ns: &str, service_name: 
     format!("{}_{}_{}", cluster_name, service_ns, service_name)
 }
 
-pub fn get_profile_client_url_name(cluster_name: &str) -> String {
+pub fn get_profile_client_url_name(cluster_name: &str) -> (String, String) {
     // SDP only allows max 20 characters
     let mut short_name: String = String::from(cluster_name);
     short_name.truncate(14);
@@ -501,7 +501,7 @@ pub fn get_profile_client_url_name(cluster_name: &str) -> String {
         .take(5)
         .map(char::from)
         .collect();
-    format!("{}-{}", short_name, random)
+    (format!("{}-{}", short_name, random), short_name)
 }
 
 pub fn containers(pod: &Pod) -> Option<&Vec<Container>> {

--- a/sdp-device-id-service/Cargo.toml
+++ b/sdp-device-id-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-device-id-service"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/Cargo.toml
+++ b/sdp-identity-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-identity-service"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/src/identity_creator.rs
+++ b/sdp-identity-service/src/identity_creator.rs
@@ -105,7 +105,7 @@ async fn get_client_profile_url(
             );
             if let Some(ps) = maybe_ps {
                 let ss: Vec<String> = ps.iter().map(|p| p.name.clone()).collect();
-                error!("Found several client profiles associated with this cluster {}: {}. They should be deleted",
+                warn!("Found several client profiles associated with this cluster {}: {}. They should be deleted",
                     cluster_id,
                     ss[..].join(",")
                 );

--- a/sdp-identity-service/src/identity_creator.rs
+++ b/sdp-identity-service/src/identity_creator.rs
@@ -47,13 +47,10 @@ async fn get_or_create_client_profile_url(
         .get_client_profiles(None)
         .await
         .map_err(|e| format!("Unable to get client profiles: {}", e.to_string()))?;
+    let (profile_name, prefix_name) = get_profile_client_url_name(cluster_id);
     let (profile_id, profile_name) = match ps
         .iter()
-        .filter(|p| {
-            let mut short_cluster_id: String = String::from(cluster_id);
-            short_cluster_id.truncate(14);
-            p.name.starts_with(&short_cluster_id)
-        })
+        .filter(|p| p.name.starts_with(&prefix_name))
         .next()
     {
         Some(p) => {
@@ -65,11 +62,10 @@ async fn get_or_create_client_profile_url(
                 "Unable to find client profile url for cluster {}, creating a new one",
                 cluster_id
             );
-            let profile_name = get_profile_client_url_name(cluster_id);
             let spa_key_name = profile_name.replace(" ", "").to_lowercase();
             let p = ClientProfile {
                 id: uuid::Uuid::new_v4().to_string(),
-                name: get_profile_client_url_name(cluster_id),
+                name: profile_name,
                 spa_key_name: spa_key_name,
                 identity_provider_name: SDP_IDP_NAME.to_string(),
                 tags: vec![],

--- a/sdp-identity-service/src/identity_creator.rs
+++ b/sdp-identity-service/src/identity_creator.rs
@@ -38,6 +38,7 @@ pub struct IdentityCreator {
     cluster_id: String,
 }
 
+#[derive(PartialEq)]
 enum ClientProfileType {
     FreshClientProfile(ClientProfile),
     ExistingClientProfile(ClientProfile),
@@ -71,7 +72,7 @@ fn get_or_create_client_profile_url<'a>(
         [p] => (ClientProfileType::ExistingClientProfile(p.clone()), None),
         _ => (
             ClientProfileType::ExistingClientProfile(a[0].clone()),
-            Some(a[0..].to_vec()),
+            Some(a[1..].to_vec()),
         ),
     }
 }

--- a/sdp-injector/Cargo.toml
+++ b/sdp-injector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-injector"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-macros/Cargo.toml
+++ b/sdp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-macros"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-proc-macros/Cargo.toml
+++ b/sdp-proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-proc-macros"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-test-macros/Cargo.toml
+++ b/sdp-test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-test-macros"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Description
This is a regression caused by #85. 

When the IdentityService generates a client profile, it uses the value from `.clusterTag`, truncates it to 14 char, and appends 5 random alphanumeric characters. Instead of looking for existing client profile that starts with `clusterTag` value, it was looking for an exact match of the generated name. On every restart, a new client profile was being created. 

The fix is to make sure IdentityService looks up existing profile by checking if any of them starts with the cluster tag. 

## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
