### PR TITLE
Remove non-ASCII character when parsing Kubernetes server version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-common"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "chrono",
  "const_format",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-device-id-service"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "clap",
  "futures",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-identity-service"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "clap",
  "futures",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-injector"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "futures",
  "futures-util",
@@ -1561,11 +1561,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-macros"
-version = "1.0.4"
+version = "1.0.5"
 
 [[package]]
 name = "sdp-proc-macros"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-test-macros"
-version = "1.0.4"
+version = "1.0.5"
 
 [[package]]
 name = "secrecy"

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.0.4"
+version: "1.0.5"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.4"
+appVersion: "1.0.5"

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.0.4"
+version: "1.0.5"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
-appVersion: "1.0.4"
+appVersion: "1.0.5"

--- a/sdp-common/Cargo.toml
+++ b/sdp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-common"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-device-id-service/Cargo.toml
+++ b/sdp-device-id-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-device-id-service"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/Cargo.toml
+++ b/sdp-identity-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-identity-service"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-injector/Cargo.toml
+++ b/sdp-injector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-injector"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-injector/src/main.rs
+++ b/sdp-injector/src/main.rs
@@ -83,7 +83,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
     };
     let sdp_sidecars: SDPSidecars =
         load_sidecar_containers().expect("Unable to load the sidecar context");
-    let version = k8s_client.apiserver_version().await?.minor.parse::<u32>()?;
+    let version = k8s_client
+        .apiserver_version()
+        .await?
+        .minor
+        .chars()
+        .filter(|c| c.is_alphanumeric())
+        .collect::<String>()
+        .parse::<u32>()?;
     info!("Found Kubernetes server version: {}", version);
     let sdp_injector_context = Arc::new(SDPInjectorContext {
         sdp_sidecars: Arc::new(sdp_sidecars),

--- a/sdp-macros/Cargo.toml
+++ b/sdp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-macros"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-proc-macros/Cargo.toml
+++ b/sdp-proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-proc-macros"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-test-macros/Cargo.toml
+++ b/sdp-test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-test-macros"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Description
Some environments return non-ASCII characters in the server version. For example, `24+`
```
Client Version: version.Info{Major:"1", Minor:"26", GitVersion:"v1.26.0", GitCommit:"b46a3f887ca979b1a5d14fd39cb1af43e7e5d12d", GitTreeState:"clean", BuildDate:"2022-12-08T19:51:43Z", GoVersion:"go1.19.4", Compiler:"gc", Platform:"darwin/arm64"}
Kustomize Version: v4.5.7
Server Version: version.Info{Major:"1", Minor:"24+", GitVersion:"v1.24.8-eks-ffeb93d", GitCommit:"abb98ec0631dfe573ec5eae40dc48fd8f2017424", GitTreeState:"clean", BuildDate:"2022-11-29T18:45:03Z", GoVersion:"go1.18.8", Compiler:"gc", Platform:"linux/amd64"}
```
Filter out the non-ASCII characters when parsing the minor in the kubernetes version. 

## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
