### PR TITLE
Support manual injection via annotation

### DIFF
--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.0.11"
+version: "1.0.12"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.7"
+appVersion: "1.0.8"

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.0.11"
+version: "1.0.12"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
-appVersion: "1.0.7"
+appVersion: "1.0.8"

--- a/sdp-injector/src/injector.rs
+++ b/sdp-injector/src/injector.rs
@@ -1366,10 +1366,12 @@ mod tests {
                                   annotations => vec![("sdp-injector", "true"),
                                                       (SDP_ANNOTATION_CLIENT_DEVICE_ID, "00000000-0000-0000-0000-000000000004"),
                                                       (SDP_ANNOTATION_DNS_SEARCHES, "ns4.one.svc.local two.svc.local svc.local"),
-                                                      (SDP_ANNOTATION_CLIENT_SECRETS, "some-secrets")]),
+                                                      (SDP_ANNOTATION_CLIENT_SECRETS, "some-secrets"),
+                                                      (SDP_ANNOTATION_CLIENT_CONFIG, "some-config")
+                    ]),
                 needs_patching: true,
                 client_secrets: "some-secrets",
-                client_config_map: "ns4-srv4-service-config",
+                client_config_map: "some-config",
                 envs: vec![
                     ("POD_N_CONTAINERS".to_string(), Some("1".to_string())),
                     (

--- a/sdp-injector/src/injector.rs
+++ b/sdp-injector/src/injector.rs
@@ -1264,12 +1264,15 @@ mod tests {
                 ..Default::default()
             },
             TestPatch {
-                pod: pod!(1, containers => vec!["random-service"],
-                annotations => vec![(SDP_ANNOTATION_CLIENT_DEVICE_ID, "00000000-0000-0000-0000-000000000001")],
-                image_pull_secrets => vec!["secret1", "secret2"],
+                pod: pod!(1,
+                containers => vec!["random-service"],
+                annotations => vec![
+                    (SDP_ANNOTATION_CLIENT_DEVICE_ID, "00000000-0000-0000-0000-000000000001")
+                ],
+                image_pull_secrets => vec!["secret1","secret2"],
                 sysctls => vec![Sysctl {
-                   name: "some.sysctl.specified.by.user".to_string(),
-                   value: "666".to_string(),
+                    name: "some.sysctl.specified.by.user".to_string(),
+                    value: "666".to_string(),
                 }]),
                 needs_patching: true,
                 envs: vec![
@@ -1305,8 +1308,9 @@ mod tests {
                 ..Default::default()
             },
             TestPatch {
-                pod: pod!(2, containers => vec!["random-service"],
-                             annotations => vec![("sdp-injector", "false")]),
+                pod: pod!(2,
+                    containers => vec!["random-service"],
+                    annotations => vec![("sdp-injector", "false")]),
                 envs: vec![
                     ("POD_N_CONTAINERS".to_string(), Some("1".to_string())),
                     (
@@ -1330,14 +1334,15 @@ mod tests {
                 ..Default::default()
             },
             TestPatch {
-                pod: pod!(3, containers => vec!["random-service"],
-                 annotations => vec![
+                pod: pod!(3,
+                containers => vec!["random-service"],
+                annotations => vec![
                     ("sdp-injector", "who-knows"),
                     (SDP_ANNOTATION_CLIENT_SECRETS, "some-secrets"),
                     (SDP_ANNOTATION_CLIENT_CONFIG, "some-config-map"),
                     (SDP_ANNOTATION_CLIENT_DEVICE_ID, "00000000-0000-0000-0000-000000000003"),
-                    (SDP_ANNOTATION_DNS_SEARCHES, "one.svc.local two.svc.local svc.local")]
-                ),
+                    (SDP_ANNOTATION_DNS_SEARCHES, "one.svc.local two.svc.local svc.local")
+                ]),
                 needs_patching: true,
                 client_config_map: "some-config-map",
                 client_secrets: "some-secrets",
@@ -1362,13 +1367,14 @@ mod tests {
                 ..Default::default()
             },
             TestPatch {
-                pod: pod!(4, containers => vec!["random-service"],
-                                  annotations => vec![("sdp-injector", "true"),
-                                                      (SDP_ANNOTATION_CLIENT_DEVICE_ID, "00000000-0000-0000-0000-000000000004"),
-                                                      (SDP_ANNOTATION_DNS_SEARCHES, "ns4.one.svc.local two.svc.local svc.local"),
-                                                      (SDP_ANNOTATION_CLIENT_SECRETS, "some-secrets"),
-                                                      (SDP_ANNOTATION_CLIENT_CONFIG, "some-config")
-                    ]),
+                pod: pod!(4,
+                containers => vec!["random-service"],
+                annotations => vec![("sdp-injector", "true"),
+                    (SDP_ANNOTATION_CLIENT_DEVICE_ID, "00000000-0000-0000-0000-000000000004"),
+                    (SDP_ANNOTATION_DNS_SEARCHES, "ns4.one.svc.local two.svc.local svc.local"),
+                    (SDP_ANNOTATION_CLIENT_SECRETS, "some-secrets"),
+                    (SDP_ANNOTATION_CLIENT_CONFIG, "some-config")
+                ]),
                 needs_patching: true,
                 client_secrets: "some-secrets",
                 client_config_map: "some-config",
@@ -1393,9 +1399,14 @@ mod tests {
                 ..Default::default()
             },
             TestPatch {
-                pod: pod!(5, containers => vec!["some-random-service-1",
-                                                     "some-random-service-2"],
-                                  annotations => vec![(SDP_ANNOTATION_CLIENT_CONFIG, "some-config-map")]),
+                pod: pod!(5,
+                containers => vec![
+                    "some-random-service-1",
+                    "some-random-service-2"
+                ],
+                annotations => vec![
+                    (SDP_ANNOTATION_CLIENT_CONFIG, "some-config-map")
+                ]),
                 needs_patching: true,
                 envs: vec![
                     ("POD_N_CONTAINERS".to_string(), Some("2".to_string())),
@@ -1417,9 +1428,12 @@ mod tests {
                 ..Default::default()
             },
             TestPatch {
-                pod: pod!(6, containers => vec![sdp_sidecar_names[0].clone(),
-                                                     sdp_sidecar_names[1].clone(),
-                                                     "some-random-service".to_string()]),
+                pod: pod!(6,
+                containers => vec![
+                    sdp_sidecar_names[0].clone(),
+                    sdp_sidecar_names[1].clone(),
+                    "some-random-service".to_string()
+                ]),
                 envs: vec![
                     ("POD_N_CONTAINERS".to_string(), Some("3".to_string())),
                     (
@@ -1438,10 +1452,13 @@ mod tests {
                 ..Default::default()
             },
             TestPatch {
-                pod: pod!(7, containers => vec![sdp_sidecar_names[0].clone(),
-                                                     sdp_sidecar_names[1].clone(),
-                                                     "some-random-service".to_string()],
-                                  annotations => vec![("sdp-injector", "true")]),
+                pod: pod!(7,
+                    containers => vec![
+                        sdp_sidecar_names[0].clone(),
+                        sdp_sidecar_names[1].clone(),
+                        "some-random-service".to_string()
+                    ],
+                    annotations => vec![("sdp-injector", "true")]),
                 envs: vec![
                     ("POD_N_CONTAINERS".to_string(), Some("3".to_string())),
                     (
@@ -1460,8 +1477,11 @@ mod tests {
                 ..Default::default()
             },
             TestPatch {
-                pod: pod!(8, containers => vec![sdp_sidecar_names[1].clone(),
-                                                     "some-random-service".to_string()]),
+                pod: pod!(8,
+                containers => vec![
+                    sdp_sidecar_names[1].clone(),
+                    "some-random-service".to_string()
+                ]),
                 envs: vec![
                     ("POD_N_CONTAINERS".to_string(), Some("2".to_string())),
                     (
@@ -1480,9 +1500,12 @@ mod tests {
                 ..Default::default()
             },
             TestPatch {
-                pod: pod!(9, containers => vec![sdp_sidecar_names[1].clone(),
-                                                    "some-random-service".to_string()],
-                                  annotations => vec![("sdp-injector", "true")]),
+                pod: pod!(9,
+                    containers => vec![
+                        sdp_sidecar_names[1].clone(),
+                        "some-random-service".to_string()
+                    ],
+                    annotations => vec![("sdp-injector", "true")]),
                 envs: vec![
                     ("POD_N_CONTAINERS".to_string(), Some("2".to_string())),
                     (
@@ -1501,8 +1524,9 @@ mod tests {
                 ..Default::default()
             },
             TestPatch {
-                pod: pod!(10, containers => vec!["random-service"],
-                                   init_containers => vec!["random-init-container"]),
+                pod: pod!(10,
+                    containers => vec!["random-service"],
+                    init_containers => vec!["random-init-container"]),
                 needs_patching: true,
                 envs: vec![
                     ("POD_N_CONTAINERS".to_string(), Some("1".to_string())),
@@ -1526,10 +1550,11 @@ mod tests {
                 ..Default::default()
             },
             TestPatch {
-                pod: pod!(11, containers => vec!["random-service"],
+                pod: pod!(11,
+                containers => vec!["random-service"],
                 sysctls => vec![Sysctl {
                     name: "some.sysctl.specified.by.user".to_string(),
-                    value: "666".to_string(),
+                    value: "666".to_string()
                 }]),
                 envs: vec![
                     ("POD_N_CONTAINERS".to_string(), Some("1".to_string())),


### PR DESCRIPTION
## Description
Allow the manual injection of SDP client using annotations. 

To enable manual injection, user is required to add the following annotations to the pod:
```yaml
  annotations:
    k8s.appgate.com/sdp-injector.device-id: "ba2349d9-03b2-428f-9d10-3c51638b2123"
    k8s.appgate.com/sdp-injector.client-config: "manual-inject-config"
    k8s.appgate.com/sdp-injector.client-secrets: "manual-inject-secret"
```

I've tested the setup with the following manifest:
```yaml
---
apiVersion: v1
kind: Secret
metadata:
  name: manual-inject-secret
  namespace: sdp-demo
type: Opaque
data:
  service-username: <USERNAME>
  service-password: <PASSWORD>
  service-url: <PROFILE_URL>
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: manual-inject-config
  namespace: sdp-demo
data:
  appgate-loglevel: INFO
---
apiVersion: v1
kind: Pod
metadata:
  name: manual-injection
  namespace: sdp-demo
  annotations:
    k8s.appgate.com/sdp-injector.device-id: "ba2349d9-03b2-428f-9d10-3c51638b2123"
    k8s.appgate.com/sdp-injector.client-config: "manual-inject-config"
    k8s.appgate.com/sdp-injector.client-secrets: "manual-inject-secret"
spec:
  containers:
  - name: dnsutils
    image: registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3
    command:
      - sleep
      - "infinity"
    imagePullPolicy: IfNotPresent
  restartPolicy: Always
```

## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
