### PR TITLE
Set MAJOR and MINOR envs for headless-service

### DIFF
--- a/docker/sdp-headless-service-Dockerfile
+++ b/docker/sdp-headless-service-Dockerfile
@@ -17,6 +17,11 @@ LABEL sdp=true
 LABEL project=sdp-client-headless
 ARG CLIENT_DEB
 
+ARG MAJOR_VERSION
+ARG MINOR_VERSION
+ENV MAJOR=${MAJOR_VERSION}
+ENV MINOR=${MINOR_VERSION}
+
 COPY --from=sdp-headless-client "/tmp/${CLIENT_DEB}" "/tmp/${CLIENT_DEB}"
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Description
Envs `MAJOR` and `MINOR` are needed for the [entrypoint script ](https://github.com/appgate/sdp-k8s-injector/blob/main/assets/sdp-client-headless-service#L42-L44)
```
# If v6.1+ client, add -l flag
if [ "$MAJOR" -ge 6 ] && [ "$MINOR" -ge 1 ]; then
    CMD="$CMD -l /var/log/appgate/driver.log"
fi
```

There is no need to bump the chart version because this is a fix for the client.