### PR TITLE
Add support for more environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-common"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "chrono",
  "const_format",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-device-id-service"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "clap",
  "futures",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-identity-service"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "clap",
  "futures",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-injector"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "futures",
  "futures-util",
@@ -1561,11 +1561,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-macros"
-version = "1.0.5"
+version = "1.0.6"
 
 [[package]]
 name = "sdp-proc-macros"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-test-macros"
-version = "1.0.5"
+version = "1.0.6"
 
 [[package]]
 name = "secrecy"

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.0.5"
+version: "1.0.6"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.5"
+appVersion: "1.0.6"

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.0.5"
+version: "1.0.6"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
-appVersion: "1.0.5"
+appVersion: "1.0.6"

--- a/sdp-common/Cargo.toml
+++ b/sdp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-common"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-common/src/kubernetes.rs
+++ b/sdp-common/src/kubernetes.rs
@@ -15,6 +15,8 @@ use crate::{
 };
 
 pub const SDP_K8S_HOST_ENV: &str = "SDP_K8S_HOST";
+pub const SDP_K8S_PORT_ENV: &str = "SDP_K8S_PORT";
+pub const SDP_K8S_PORT_DEFAULT: &str = "443";
 pub const SDP_K8S_HOST_DEFAULT: &str = "kubernetes.default.svc";
 pub const SDP_K8S_NO_VERIFY_ENV: &str = "SDP_K8S_NO_VERIFY";
 pub const SDP_K8S_NAMESPACE: &str = "sdp-system";
@@ -23,6 +25,8 @@ pub const KUBE_SYSTEM_NAMESPACE: &str = "kube-system";
 pub async fn get_k8s_client() -> Client {
     let mut k8s_host = String::from("https://");
     k8s_host.push_str(&std::env::var(SDP_K8S_HOST_ENV).unwrap_or(SDP_K8S_HOST_DEFAULT.to_string()));
+    k8s_host.push_str(":");
+    k8s_host.push_str(&std::env::var(SDP_K8S_PORT_ENV).unwrap_or(SDP_K8S_PORT_DEFAULT.to_string()));
     let k8s_uri = k8s_host
         .parse::<Uri>()
         .expect(format!("Unable to parse SDP_K8S_HOST value: {}", k8s_host).as_str());

--- a/sdp-common/src/sdp/system.rs
+++ b/sdp-common/src/sdp/system.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use uuid::Uuid;
 
 const SDP_SYSTEM_HOSTS: &str = "SDP_SYSTEM_HOSTS";
+const SDP_SYSTEM_NO_VERIFY_ENV: &str = "SDP_SYSTEM_NO_VERIFY";
 const SDP_SYSTEM_API_VERSION: &str = "v17";
 const SDP_SYSTEM_USERNAME: &str = "SDP_K8S_USERNAME";
 const SDP_SYSTEM_USERNAME_DEFAULT: &str = "admin";
@@ -88,9 +89,13 @@ impl SystemConfig {
         let hm = self
             .headers()
             .map_err(|e| format!("Unable to create SDP client: {}", e))?;
+        let no_verify = match std::env::var(SDP_SYSTEM_NO_VERIFY_ENV) {
+            Ok(v) if v == "1" || v.to_lowercase() == "true" => true,
+            _ => false,
+        };
         Client::builder()
             .default_headers(hm)
-            .danger_accept_invalid_certs(true)
+            .danger_accept_invalid_certs(no_verify)
             .build()
             .map_err(|e| format!("Unable to create SDP client: {}", e))
             .map(|c| System {

--- a/sdp-device-id-service/Cargo.toml
+++ b/sdp-device-id-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-device-id-service"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/Cargo.toml
+++ b/sdp-identity-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-identity-service"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-injector/Cargo.toml
+++ b/sdp-injector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-injector"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-macros/Cargo.toml
+++ b/sdp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-macros"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-proc-macros/Cargo.toml
+++ b/sdp-proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-proc-macros"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-test-macros/Cargo.toml
+++ b/sdp-test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-test-macros"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Description

Added support to configure via environment variables:
 
 - SDP_K8S_PORT :: port to connect to k8s API, defaults to 443
 - SDP_SYSTEM_NO_VERIFY :: disable certs verification for local testing, defaults to false.


## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
