### PR TITLE
Add readiness probe to the sdp-service container

### DIFF
--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.0.6"
+version: "1.0.7"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/chart/templates/configmap-sidecar.yaml
+++ b/k8s/chart/templates/configmap-sidecar.yaml
@@ -64,7 +64,18 @@ data:
               "mountPath": "/etc/pod-info",
               "name": "pod-info"
             }
-          ]
+          ],
+          "readinessProbe": {
+            "exec": {
+              "command": [
+                "grep",
+                "Authentication succeeded.",
+                "/var/log/appgate-headless/log.log"
+              ]
+            },
+            "initialDelaySeconds": 5,
+            "periodSeconds": 5
+          }
         },
         {
           "name": "sdp-driver",

--- a/k8s/chart/templates/configmap-sidecar.yaml
+++ b/k8s/chart/templates/configmap-sidecar.yaml
@@ -68,13 +68,12 @@ data:
           "readinessProbe": {
             "exec": {
               "command": [
-                "grep",
-                "Authentication succeeded.",
-                "/var/log/appgate-headless/log.log"
+                "sh",
+                "-c",
+                "appgate_service_configurator status | grep '\"status\": \"Connected\"'"
               ]
             },
-            "initialDelaySeconds": 5,
-            "periodSeconds": 5
+            "initialDelaySeconds": 10
           }
         },
         {

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.0.6"
+version: "1.0.7"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
 appVersion: "1.0.6"


### PR DESCRIPTION
## Description
Add readinessProbe to sdp-service container by calling `grep "Authentication succeeded." /var/log/appgate-headless/log.log`. The probe will only start running after a 5 second delay and retry 3 times with a 5 second wait. 

Instead of silently failing, the failed probe will alert the users about any authentication issues with the service. The error will be displayed under the Events section when you describe the pod, like this:
```
Warning  Unhealthy  95s (x63 over 6m30s)  kubelet            Readiness probe failed: 
```

## Checklist
- [x] Bump `.version` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version`  in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
