### PR TITLE
Fix init container and argument in chart configuration

### DIFF
--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.0.10"
+version: "1.0.11"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/chart/templates/configmap-sidecar.yaml
+++ b/k8s/chart/templates/configmap-sidecar.yaml
@@ -20,7 +20,7 @@ data:
           "command" : [
             "sh",
             "-c",
-            "echo \"nameserver $K8S_DNS_SERVICE\n$K8S_DNS_SEARCHES\"> /etc/resolv.conf"
+            "echo \"nameserver $K8S_DNS_SERVICE\nsearch $K8S_DNS_SEARCHES\"> /etc/resolv.conf"
           ]
         },
         {
@@ -34,7 +34,7 @@ data:
           "command" : [
             "sh",
             "-c",
-            "echo \"nameserver 127.0.0.1\n$K8S_DNS_SEARCHES\"> /etc/resolv.conf"
+            "echo \"nameserver 127.0.0.1\nsearch $K8S_DNS_SEARCHES\"> /etc/resolv.conf"
           ]
         }
       ],

--- a/k8s/chart/templates/sdp-identity-service.yaml
+++ b/k8s/chart/templates/sdp-identity-service.yaml
@@ -129,7 +129,7 @@ spec:
         - name: {{ .Chart.Name }}-identity-service
           env:
             - name: SDP_SYSTEM_NO_VERIFY
-              value: {{ .Values.sdp.sdpSystemNoVerify | quote }}
+              value: {{ .Values.sdp.identityService.sdpSystemNoVerify | quote }}
             - name: SDP_LOG_CONFIG_FILE
               value: /opt/sdp-identity-service/log4rs.yaml
             - name: SDP_SYSTEM_HOSTS

--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -82,7 +82,7 @@ sdp:
   ## @param sdp.identityService.image.tag SDP Identity Service image tag. If set, it overrides `.chart.appVersion`.
   ## @param sdp.identityService.image.pullPolicy SDP Identity Service pull policy. If set, it overrides `.global.image.pullPolicy`.
   identityService:
-    sdpSystemNoVerify: 0
+    sdpSystemNoVerify: "false"
     logLevel: info
     replica: 1
     image:

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.0.10"
+version: "1.0.11"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
 appVersion: "1.0.7"


### PR DESCRIPTION
## Description

Init containers where not getting a proper search domains configuration in the init containers


## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
