### PR TITLE
Push client images with commit hash in tag

### DIFF
--- a/.github/workflows/build-push-client.yml
+++ b/.github/workflows/build-push-client.yml
@@ -35,6 +35,9 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get commit short hash
+        run: echo GIT_COMMIT=$(git rev-parse --short "$GITHUB_SHA") >> $GITHUB_ENV
+
       - name: Split version into major/minor/maintenance
         uses: jungwinter/split@v2
         id: split
@@ -53,6 +56,7 @@ jobs:
             MINOR_VERSION=${{ steps.split.outputs._1 }}
           tags: |
             ghcr.io/${{ github.repository }}/${{ matrix.bin }}:${{ matrix.client-version }}
+            ghcr.io/${{ github.repository }}/${{ matrix.bin }}:${{ matrix.client-version }}-${{ env.GIT_COMMIT }}
 
       - name: Tag latest image
         uses: docker/build-push-action@v4

--- a/.github/workflows/build-push-client.yml
+++ b/.github/workflows/build-push-client.yml
@@ -24,10 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
## Description
In addition to pushing the client images `6.1` `6.0` and `5.5`, push another tag that contains the commit hash `6.1-abcedfg`
