### PR TITLE
Fix race condition

### DIFF
--- a/.github/workflows/build-push-injector.yml
+++ b/.github/workflows/build-push-injector.yml
@@ -40,6 +40,9 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get commit short hash
+        run: echo GIT_COMMIT=$(git rev-parse --short "$GITHUB_SHA") >> $GITHUB_ENV
+
       - name: Build cached layer
         uses: docker/build-push-action@v5
         with:
@@ -58,6 +61,7 @@ jobs:
           push: ${{ inputs.push }}
           tags: |
             ghcr.io/${{ github.repository }}/sdp-device-id-service:${{ env.VERSION }}
+            ghcr.io/${{ github.repository }}/sdp-device-id-service:${{ env.VERSION }}-${{ env.GIT_COMMIT }}
             ghcr.io/${{ github.repository }}/sdp-device-id-service:latest
 
       - name: Build sdp-identity-service
@@ -69,6 +73,7 @@ jobs:
           push: ${{ inputs.push }}
           tags: |
             ghcr.io/${{ github.repository }}/sdp-identity-service:${{ env.VERSION }}
+            ghcr.io/${{ github.repository }}/sdp-identity-service:${{ env.VERSION }}-${{ env.GIT_COMMIT }}
             ghcr.io/${{ github.repository }}/sdp-identity-service:latest
 
       - name: Build sdp-injector
@@ -80,4 +85,5 @@ jobs:
           push: ${{ inputs.push }}
           tags: |
             ghcr.io/${{ github.repository }}/sdp-injector:${{ env.VERSION }}
+            ghcr.io/${{ github.repository }}/sdp-injector:${{ env.VERSION }}-${{ env.GIT_COMMIT }}
             ghcr.io/${{ github.repository }}/sdp-injector:latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-common"
+<<<<<<< HEAD
 version = "1.1.1"
+=======
+version = "1.0.8"
+>>>>>>> de54da8 (Bump version)
 dependencies = [
  "chrono",
  "const_format",
@@ -1660,7 +1664,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-device-id-service"
+<<<<<<< HEAD
 version = "1.1.1"
+=======
+version = "1.0.8"
+>>>>>>> de54da8 (Bump version)
 dependencies = [
  "clap",
  "futures",
@@ -1679,7 +1687,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-identity-service"
+<<<<<<< HEAD
 version = "1.1.1"
+=======
+version = "1.0.8"
+>>>>>>> de54da8 (Bump version)
 dependencies = [
  "clap",
  "futures",
@@ -1699,7 +1711,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-injector"
+<<<<<<< HEAD
 version = "1.1.1"
+=======
+version = "1.0.8"
+>>>>>>> de54da8 (Bump version)
 dependencies = [
  "futures",
  "futures-util",
@@ -1726,11 +1742,19 @@ dependencies = [
 
 [[package]]
 name = "sdp-macros"
+<<<<<<< HEAD
 version = "1.1.1"
 
 [[package]]
 name = "sdp-proc-macros"
 version = "1.1.1"
+=======
+version = "1.0.8"
+
+[[package]]
+name = "sdp-proc-macros"
+version = "1.0.8"
+>>>>>>> de54da8 (Bump version)
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1739,7 +1763,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-test-macros"
+<<<<<<< HEAD
 version = "1.1.1"
+=======
+version = "1.0.8"
+>>>>>>> de54da8 (Bump version)
 
 [[package]]
 name = "secrecy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,11 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-common"
-<<<<<<< HEAD
 version = "1.1.1"
-=======
-version = "1.0.8"
->>>>>>> de54da8 (Bump version)
 dependencies = [
  "chrono",
  "const_format",
@@ -1664,11 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-device-id-service"
-<<<<<<< HEAD
 version = "1.1.1"
-=======
-version = "1.0.8"
->>>>>>> de54da8 (Bump version)
 dependencies = [
  "clap",
  "futures",
@@ -1687,11 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-identity-service"
-<<<<<<< HEAD
 version = "1.1.1"
-=======
-version = "1.0.8"
->>>>>>> de54da8 (Bump version)
 dependencies = [
  "clap",
  "futures",
@@ -1711,11 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-injector"
-<<<<<<< HEAD
 version = "1.1.1"
-=======
-version = "1.0.8"
->>>>>>> de54da8 (Bump version)
 dependencies = [
  "futures",
  "futures-util",
@@ -1742,19 +1726,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-macros"
-<<<<<<< HEAD
 version = "1.1.1"
 
 [[package]]
 name = "sdp-proc-macros"
 version = "1.1.1"
-=======
-version = "1.0.8"
-
-[[package]]
-name = "sdp-proc-macros"
-version = "1.0.8"
->>>>>>> de54da8 (Bump version)
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1763,11 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-test-macros"
-<<<<<<< HEAD
 version = "1.1.1"
-=======
-version = "1.0.8"
->>>>>>> de54da8 (Bump version)
 
 [[package]]
 name = "secrecy"

--- a/sdp-identity-service/src/identity_manager.rs
+++ b/sdp-identity-service/src/identity_manager.rs
@@ -1810,7 +1810,7 @@ mod tests {
                     .await.expect("Unable to send message!");
                 // Notify that IdentityCreator is ready
                 tx.send(IdentityManagerProtocol::IdentityCreatorReady).await.expect("Unable to send message!");
-                // Notify the DeploymentWatcher is ready
+                // We expect 2 DeploymentWatchers to report readiness
                 tx.send(IdentityManagerProtocol::DeploymentWatcherReady).await.expect("Unable to send message!");
                 tx.send(IdentityManagerProtocol::DeploymentWatcherReady).await.expect("Unable to send message!");
                 let mut extra_credentials_expected: HashSet<String> = HashSet::from_iter((1 .. 12).map(|i| format!("service_user_id{}", i)).collect::<Vec<_>>());
@@ -1844,6 +1844,7 @@ mod tests {
                 assert_message!(m :: IdentityManagerProtocol::IdentityManagerStarted in watcher_rx);
                 let tx = identity_manager_tx.clone();
                 tx.send(IdentityManagerProtocol::IdentityCreatorReady).await.expect("Unable to send message!");
+                // We expect 2 DeploymentWatchers to report readiness
                 tx.send(IdentityManagerProtocol::DeploymentWatcherReady).await.expect("Unable to send message!");
                 tx.send(IdentityManagerProtocol::DeploymentWatcherReady).await.expect("Unable to send message!");
                 // Syncing UserCredentials log message

--- a/sdp-identity-service/src/identity_manager.rs
+++ b/sdp-identity-service/src/identity_manager.rs
@@ -379,7 +379,7 @@ impl IdentityManagerRunner<ServiceLookup, ServiceIdentity> {
         external_queue_tx: Option<&Sender<IdentityManagerProtocol<F, ServiceIdentity>>>,
     ) -> () {
         info!("Starting Identity Manager");
-        let mut deployment_watcher_ready: u8 = 0;
+        let mut deployment_watchers_ready: u8 = 0;
         let mut identity_creator_ready = false;
         let mut existing_service_candidates: HashSet<String> = HashSet::new();
         let mut missing_service_candidates: HashMap<String, F> = HashMap::new();
@@ -570,7 +570,7 @@ impl IdentityManagerRunner<ServiceLookup, ServiceIdentity> {
                 IdentityManagerProtocol::IdentityCreatorReady => {
                     info!("IdentityCreator is ready");
                     identity_creator_ready = true;
-                    if deployment_watcher_ready == N_WATCHERS {
+                    if deployment_watchers_ready == N_WATCHERS {
                         info!("IdentityManager is ready");
                         if let Err(e) = identity_manager_tx
                             .send(IdentityManagerProtocol::IdentityManagerReady)
@@ -587,8 +587,8 @@ impl IdentityManagerRunner<ServiceLookup, ServiceIdentity> {
                 }
                 IdentityManagerProtocol::DeploymentWatcherReady => {
                     info!("DeploymentWatcher is ready");
-                    deployment_watcher_ready += 1;
-                    if deployment_watcher_ready == N_WATCHERS && identity_creator_ready {
+                    deployment_watchers_ready += 1;
+                    if deployment_watchers_ready == N_WATCHERS && identity_creator_ready {
                         if let Err(e) = identity_manager_tx
                             .send(IdentityManagerProtocol::IdentityManagerReady)
                             .await

--- a/sdp-identity-service/src/identity_manager.rs
+++ b/sdp-identity-service/src/identity_manager.rs
@@ -1812,6 +1812,7 @@ mod tests {
                 tx.send(IdentityManagerProtocol::IdentityCreatorReady).await.expect("Unable to send message!");
                 // Notify the DeploymentWatcher is ready
                 tx.send(IdentityManagerProtocol::DeploymentWatcherReady).await.expect("Unable to send message!");
+                tx.send(IdentityManagerProtocol::DeploymentWatcherReady).await.expect("Unable to send message!");
                 let mut extra_credentials_expected: HashSet<String> = HashSet::from_iter((1 .. 12).map(|i| format!("service_user_id{}", i)).collect::<Vec<_>>());
                 for _ in 1 .. 12 {
                     assert_message!(m :: IdentityCreatorProtocol::DeleteSDPUser(_) in identity_creator_rx);
@@ -1843,6 +1844,7 @@ mod tests {
                 assert_message!(m :: IdentityManagerProtocol::IdentityManagerStarted in watcher_rx);
                 let tx = identity_manager_tx.clone();
                 tx.send(IdentityManagerProtocol::IdentityCreatorReady).await.expect("Unable to send message!");
+                tx.send(IdentityManagerProtocol::DeploymentWatcherReady).await.expect("Unable to send message!");
                 tx.send(IdentityManagerProtocol::DeploymentWatcherReady).await.expect("Unable to send message!");
                 // Syncing UserCredentials log message
                 assert_message!(m :: IdentityManagerProtocol::IdentityManagerDebug(_) in watcher_rx);


### PR DESCRIPTION
## Description

Fix a bug introduced when we implemented support for `SDPService` CRD.

We have 2 `DeploymentWatchers` (1 for `SDPService` and another for `Deployments`) but the `IdentityManager` was expecting only 1 of them to report the ready event. This was causing the garbage collector code to run too early deleting service identities and service users.

This PR also adds a new tag in the containers: `version-short_hash`

## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
