### PR TITLE
Kill sdp-service if it fails to connect after x seconds

### DIFF
--- a/assets/sdp-client-headless-service
+++ b/assets/sdp-client-headless-service
@@ -65,4 +65,7 @@ while
     fi
 do :; done
 
+# startupProbe checks for the existence of this file
+touch /sdp-service/ready
+
 wait -n

--- a/assets/sdp-client-headless-service
+++ b/assets/sdp-client-headless-service
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/bash
 
 # Backwards compatibility for alpha version
 if [ -n "$CLIENT_LOGLEVEL" ]; then
@@ -64,3 +64,5 @@ while
       break;
     fi
 do :; done
+
+wait -n

--- a/assets/sdp-client-headless-service
+++ b/assets/sdp-client-headless-service
@@ -43,4 +43,24 @@ if [ "$MAJOR" -ge 6 ] && [ "$MINOR" -ge 1 ]; then
     CMD="$CMD -l /var/log/appgate/driver.log"
 fi
 
-eval "${CMD}"
+eval "${CMD}" &
+
+COUNT=0
+MAX_COUNT=10
+SLEEP=10
+while
+    :
+    COUNT="$((COUNT+1))"
+    if [ "$COUNT" -gt "$MAX_COUNT" ]; then
+        echo "Unable to connect the service after $((MAX_COUNT*SLEEP)) seconds. Exiting."
+        exit 1
+    fi
+
+    sleep $SLEEP
+
+    STATUS="$(appgate_service_configurator status | jq -r .status)"
+    echo "Status: $STATUS ($COUNT/$MAX_COUNT)"
+    if [ "$STATUS" = "Connected" ]; then
+      break;
+    fi
+do :; done

--- a/docker/sdp-headless-service-Dockerfile
+++ b/docker/sdp-headless-service-Dockerfile
@@ -25,7 +25,8 @@ ENV MINOR=${MINOR_VERSION}
 COPY --from=sdp-headless-client "/tmp/${CLIENT_DEB}" "/tmp/${CLIENT_DEB}"
 
 RUN apt-get update && apt-get install -y \
-        "/tmp/$CLIENT_DEB" && \
+        "/tmp/$CLIENT_DEB" \
+        jq && \
     rm -rf /var/lib/apt/lists/* && \
     groupmod -g 103 messagebus && \
     addgroup dnsmasq --gid 101 && \

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.0.11"
+version: "1.0.12"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/chart/templates/configmap-sidecar.yaml
+++ b/k8s/chart/templates/configmap-sidecar.yaml
@@ -65,6 +65,19 @@ data:
               "name": "pod-info"
             }
           ],
+          "startupProbe": {
+            "exec": {
+              "command": [
+                 "sh",
+                 "-c",
+                 "test",
+                 "-f",
+                 "/sdp-service/ready"
+               ]
+            },
+            "failureThreshold": 10,
+            "periodSeconds": 10
+          },
           "readinessProbe": {
             "exec": {
               "command": [

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.0.11"
+version: "1.0.12"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
 appVersion: "1.0.7"


### PR DESCRIPTION
## Description
Perform a healthcheck ourselves during the initialization of the service by polling the configurator for status. 

If the status does not reach `Connected`, kill the container with exit code 1. 

If the status reaches `Connected`, create a file in `/sdp-service/ready` to signal Kubernetes that the container is ready to start running the readiness probe (using startup probe), delegating the health check to Kubernetes from there onwards. 

## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
~[] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)~
