### PR TITLE
Bump rust binary versions to 1.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-common"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "chrono",
  "const_format",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-device-id-service"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "clap",
  "futures",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-identity-service"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "clap",
  "futures",
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-injector"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "futures",
  "futures-util",
@@ -1650,11 +1650,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-macros"
-version = "1.0.8"
+version = "1.0.9"
 
 [[package]]
 name = "sdp-proc-macros"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-test-macros"
-version = "1.0.8"
+version = "1.0.9"
 
 [[package]]
 name = "secrecy"

--- a/sdp-common/Cargo.toml
+++ b/sdp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-common"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-device-id-service/Cargo.toml
+++ b/sdp-device-id-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-device-id-service"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/Cargo.toml
+++ b/sdp-identity-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-identity-service"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-injector/Cargo.toml
+++ b/sdp-injector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-injector"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-macros/Cargo.toml
+++ b/sdp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-macros"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-proc-macros/Cargo.toml
+++ b/sdp-proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-proc-macros"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-test-macros/Cargo.toml
+++ b/sdp-test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-test-macros"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Description
* Bump rust binary versions to 1.0.9 so it gets pushed to ghcr
