### PR TITLE
Fix pre-6.2 client images by reverting to ubuntu

### DIFF
--- a/.github/workflows/build-push-client.yml
+++ b/.github/workflows/build-push-client.yml
@@ -11,7 +11,7 @@ on:
         type: string
 
 jobs:
-  docker-build-client:
+  docker-build-client-old:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -22,6 +22,49 @@ jobs:
         client-version:
           - "6.0"
           - "6.1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ inputs.push }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get commit short hash
+        run: echo GIT_COMMIT=$(git rev-parse --short "$GITHUB_SHA") >> $GITHUB_ENV
+
+      - name: Split version into major/minor/maintenance
+        uses: jungwinter/split@v2
+        id: split
+        with:
+          msg: ${{ matrix.client-version }}
+          separator: '.'
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/pre-6.2/${{ matrix.binary }}-Dockerfile-old
+          push: ${{ inputs.push }}
+          build-args: |
+            MAJOR_VERSION=${{ steps.split.outputs._0 }}
+            MINOR_VERSION=${{ steps.split.outputs._1 }}
+          tags: |
+            ghcr.io/${{ github.repository }}/${{ matrix.binary }}:${{ matrix.client-version }}
+            ghcr.io/${{ github.repository }}/${{ matrix.binary }}:${{ matrix.client-version }}-${{ env.GIT_COMMIT }}
+
+  docker-build-client:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        binary:
+          - "sdp-dnsmasq"
+          - "sdp-headless-driver"
+          - "sdp-headless-service"
+        client-version:
           - "6.2"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pull-request-client.yml
+++ b/.github/workflows/pull-request-client.yml
@@ -9,6 +9,9 @@ on:
       - docker/sdp-dnsmasq-Dockerfile
       - docker/sdp-headless-driver-Dockerfile
       - docker/sdp-headless-service-Dockerfile
+      - docker/pre-6.2/sdp-dnsmasq-Dockerfile-old
+      - docker/pre-6.2/sdp-headless-driver-Dockerfile-old
+      - docker/pre-6.2/sdp-headless-service-Dockerfile-old
 
 jobs:
   build-client:

--- a/docker/pre-6.2/sdp-dnsmasq-Dockerfile-old
+++ b/docker/pre-6.2/sdp-dnsmasq-Dockerfile-old
@@ -1,0 +1,18 @@
+FROM alpine:3.14.0
+LABEL sdp=true
+LABEL project=sdp-injector
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual=run-deps dnsmasq socat && \
+    rm -rf /tmp/* \
+           /var/cache/apk/* \
+           /var/tmp/*
+COPY assets/sdp-dnsmasq /sdp-dnsmasq/sdp-dnsmasq
+COPY assets/sdp-dnsmasq-set-dns /sdp-dnsmasq/sdp-dnsmasq-set-dns
+RUN mkdir /var/run/sdp-dnsmasq && \
+    mkdir -p /sdp-dnsmasq/dnsmasq.d && \
+    chown 100:101 /var/run/sdp-dnsmasq -R && \
+    chown 100:101 /sdp-dnsmasq/ -R && \
+    chmod +x /sdp-dnsmasq/sdp-dnsmasq
+WORKDIR /sdp-dnsmasq
+USER dnsmasq
+CMD ["/sdp-dnsmasq/sdp-dnsmasq"]

--- a/docker/pre-6.2/sdp-headless-driver-Dockerfile-old
+++ b/docker/pre-6.2/sdp-headless-driver-Dockerfile-old
@@ -1,0 +1,59 @@
+ARG MAJOR_VERSION
+ARG MINOR_VERSION
+ARG CLIENT_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}"
+ARG CLIENT_DEB="appgate-sdp-headless_${CLIENT_FULL_VERSION}_amd64.deb"
+
+FROM alpine AS sdp-headless-client
+ARG CLIENT_VERSION
+ARG CLIENT_DEB
+
+RUN apk add --no-cache jq curl
+RUN curl "https://bin.appgate-sdp.com/latest/client.json" --output "/tmp/latest.json"
+ARG QUERY='.releases.'\"${CLIENT_VERSION}\"'[] | select(.os == "ubuntu" and .type == "headless") | .link'
+RUN curl $(jq "${QUERY}" /tmp/latest.json --raw-output) --output "/tmp/${CLIENT_DEB}"
+
+FROM ubuntu:18.04
+LABEL sdp=true
+LABEL project=sdp-client-headless
+ARG CLIENT_DEB
+
+COPY --from=sdp-headless-client "/tmp/${CLIENT_DEB}" "/tmp/${CLIENT_DEB}"
+RUN apt-get update && apt-get install -y \
+        "/tmp/$CLIENT_DEB" && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupmod -g 103 messagebus && \
+    addgroup dnsmasq --gid 101 && \
+    usermod _apt -u 104 && \
+    usermod dnsmasq -u 100 -g 101 && \
+    usermod appgate -a -G dnsmasq
+
+RUN apt-get update && apt-get install -y \
+        iproute2 \
+        socat \
+        libcap2-bin \
+        && rm -rf /var/lib/apt/lists/*
+
+COPY assets/sdp-driver-set-dns /opt/appgate/linux/set_dns
+COPY assets/sdp-client-headless-driver /opt/appgate/sdp-client-headless-driver
+RUN mkdir /var/run/sdp-driver && \
+    chown -R 103:102 /var/run/sdp-driver && \
+    chmod +x /opt/appgate/linux/set_dns && \
+    chmod +x /opt/appgate/sdp-client-headless-driver && \
+    chown -R 103:102 /opt/appgate && \
+    mkdir -p /var/log/appgate && \
+    chown -R 103:102 /var/log/appgate && \
+    rm -rf \
+        /usr/share/doc \
+        /usr/share/man \
+        /var/lib/apt \
+        /var/lib/dpkg \
+        /var/cache \
+        /etc/machine-id \
+        /tmp/$CLIENT_DEB && \
+    setcap CAP_NET_ADMIN+ep /bin/ip && \
+    setcap CAP_NET_ADMIN,CAP_NET_RAW+ep /sbin/xtables-multi && \
+    setcap CAP_NET_ADMIN=ep /opt/appgate/appgate-driver && \
+    setcap CAP_MKNOD=ep /bin/mknod
+WORKDIR /opt/appgate
+USER appgate
+CMD ["/opt/appgate/sdp-client-headless-driver"]

--- a/docker/pre-6.2/sdp-headless-service-Dockerfile-old
+++ b/docker/pre-6.2/sdp-headless-service-Dockerfile-old
@@ -1,0 +1,59 @@
+ARG MAJOR_VERSION
+ARG MINOR_VERSION
+ARG CLIENT_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}"
+ARG CLIENT_DEB="appgate-sdp-headless_${CLIENT_FULL_VERSION}_amd64.deb"
+
+FROM alpine AS sdp-headless-client
+ARG CLIENT_VERSION
+ARG CLIENT_DEB
+
+RUN apk add --no-cache jq curl
+RUN curl "https://bin.appgate-sdp.com/latest/client.json" --output "/tmp/latest.json"
+ARG QUERY='.releases.'\"${CLIENT_VERSION}\"'[] | select(.os == "ubuntu" and .type == "headless") | .link'
+RUN curl $(jq "${QUERY}" /tmp/latest.json --raw-output) --output "/tmp/${CLIENT_DEB}"
+
+FROM ubuntu:18.04
+LABEL sdp=true
+LABEL project=sdp-client-headless
+ARG CLIENT_DEB
+
+COPY --from=sdp-headless-client "/tmp/${CLIENT_DEB}" "/tmp/${CLIENT_DEB}"
+RUN apt-get update && apt-get install -y \
+        "/tmp/$CLIENT_DEB" && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupmod -g 103 messagebus && \
+    addgroup dnsmasq --gid 101 && \
+    usermod _apt -u 104 && \
+    usermod dnsmasq -u 100 -g 101 && \
+    usermod appgate -a -G dnsmasq
+
+RUN apt-get update && apt-get install -y \
+        iproute2 \
+        socat \
+        libcap2-bin \
+        && rm -rf /var/lib/apt/lists/*
+
+COPY assets/sdp-driver-set-dns /opt/appgate/linux/set_dns
+COPY assets/sdp-client-headless-driver /opt/appgate/sdp-client-headless-driver
+RUN mkdir /var/run/sdp-driver && \
+    chown -R 103:102 /var/run/sdp-driver && \
+    chmod +x /opt/appgate/linux/set_dns && \
+    chmod +x /opt/appgate/sdp-client-headless-driver && \
+    chown -R 103:102 /opt/appgate && \
+    mkdir -p /var/log/appgate && \
+    chown -R 103:102 /var/log/appgate && \
+    rm -rf \
+        /usr/share/doc \
+        /usr/share/man \
+        /var/lib/apt \
+        /var/lib/dpkg \
+        /var/cache \
+        /etc/machine-id \
+        /tmp/$CLIENT_DEB && \
+    setcap CAP_NET_ADMIN+ep /bin/ip && \
+    setcap CAP_NET_ADMIN,CAP_NET_RAW+ep /sbin/xtables-multi && \
+    setcap CAP_NET_ADMIN=ep /opt/appgate/appgate-driver && \
+    setcap CAP_MKNOD=ep /bin/mknod
+WORKDIR /opt/appgate
+USER appgate
+CMD ["/opt/appgate/sdp-client-headless-driver"]


### PR DESCRIPTION
6.0 and 6.1 client do not contain the fix to work in latest Ubuntu or Debian. We need to use the old Dockerfile with Ubuntu 18 for these clients because the `ip` fix will not be backported to these versions. 