### PR TITLE
Inspect .labels["k8s-app"] to find Kube DNS Service + Add rke2-coredns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-common"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "chrono",
  "const_format",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-device-id-service"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "clap",
  "futures",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-identity-service"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "clap",
  "futures",
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-injector"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "futures",
  "futures-util",
@@ -1650,11 +1650,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-macros"
-version = "1.0.10"
+version = "1.0.11"
 
 [[package]]
 name = "sdp-proc-macros"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-test-macros"
-version = "1.0.10"
+version = "1.0.11"
 
 [[package]]
 name = "secrecy"

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.0.14"
+version: "1.0.15"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.10"
+appVersion: "1.0.11"

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.0.14"
+version: "1.0.15"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
-appVersion: "1.0.10"
+appVersion: "1.0.11"

--- a/sdp-common/Cargo.toml
+++ b/sdp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-common"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-device-id-service/Cargo.toml
+++ b/sdp-device-id-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-device-id-service"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/Cargo.toml
+++ b/sdp-identity-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-identity-service"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-injector/Cargo.toml
+++ b/sdp-injector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-injector"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-injector/src/injector.rs
+++ b/sdp-injector/src/injector.rs
@@ -336,9 +336,17 @@ async fn dns_service_discover(services_api: &Api<KubeService>) -> Option<KubeSer
             let mut iter = xs.items.into_iter();
             iter.find(|s| {
                 s.metadata
-                    .name
+                    .labels
                     .as_ref()
-                    .map(|ns| names.contains(ns.as_str()))
+                    .and_then(|l| {
+                        let maybe_dns_service = l.get("k8s-app");
+                        debug!(
+                            "Kubernetes DNS Service: {}",
+                            maybe_dns_service.unwrap_or("None")
+                        );
+                        maybe_dns_service
+                    })
+                    .map(|l| names.contains(l.as_str()))
                     .unwrap_or(false)
             })
         })

--- a/sdp-injector/src/injector.rs
+++ b/sdp-injector/src/injector.rs
@@ -341,10 +341,9 @@ async fn dns_service_discover(services_api: &Api<KubeService>) -> Option<KubeSer
                     .and_then(|l| {
                         // k8s-app label is by design: https://github.com/coredns/deployment/issues/116
                         let maybe_dns_service = l.get("k8s-app");
-                        debug!(
-                            "Kubernetes DNS Service: {}",
-                            maybe_dns_service.unwrap_or(&"None".to_string())
-                        );
+                        if let Some(dns) = maybe_dns_service {
+                            info!("Kubernetes DNS Service: {}", dns);
+                        }
                         maybe_dns_service
                     })
                     .map(|l| names.contains(l.as_str()))

--- a/sdp-injector/src/injector.rs
+++ b/sdp-injector/src/injector.rs
@@ -342,7 +342,7 @@ async fn dns_service_discover(services_api: &Api<KubeService>) -> Option<KubeSer
                         let maybe_dns_service = l.get("k8s-app");
                         debug!(
                             "Kubernetes DNS Service: {}",
-                            maybe_dns_service.unwrap_or("None")
+                            maybe_dns_service.unwrap_or(&"None".to_string())
                         );
                         maybe_dns_service
                     })

--- a/sdp-injector/src/injector.rs
+++ b/sdp-injector/src/injector.rs
@@ -339,6 +339,7 @@ async fn dns_service_discover(services_api: &Api<KubeService>) -> Option<KubeSer
                     .labels
                     .as_ref()
                     .and_then(|l| {
+                        // k8s-app label is by design: https://github.com/coredns/deployment/issues/116
                         let maybe_dns_service = l.get("k8s-app");
                         debug!(
                             "Kubernetes DNS Service: {}",

--- a/sdp-injector/src/injector.rs
+++ b/sdp-injector/src/injector.rs
@@ -56,7 +56,7 @@ use sdp_macros::{logger, sdp_debug, sdp_error, sdp_info, sdp_log, sdp_warn, with
 
 logger!("SDPInjector");
 
-const SDP_DNS_SERVICE_NAMES: [&str; 2] = ["kube-dns", "coredns"];
+const SDP_DNS_SERVICE_NAMES: [&str; 3] = ["kube-dns", "coredns", "rke2-coredns"];
 const SDP_SIDECARS_FILE: &str = "/opt/sdp-injector/k8s/sdp-sidecars.json";
 const SDP_SIDECARS_FILE_ENV: &str = "SDP_SIDECARS_FILE";
 const SDP_CERT_FILE_ENV: &str = "SDP_CERT_FILE";

--- a/sdp-macros/Cargo.toml
+++ b/sdp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-macros"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-proc-macros/Cargo.toml
+++ b/sdp-proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-proc-macros"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-test-macros/Cargo.toml
+++ b/sdp-test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-test-macros"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Description
* Instead of looking at `.metadata.name` of the service, look at the `labels["k8s-app"]` to find the matching DNS service name
* Add `rke2-coredns` as an option to the Kube DNS Service option

## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
