### PR TITLE
Fix a couple of bugs: deleting old secrets on startup cleanup and updating old secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-common"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "chrono",
  "const_format",
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-identity-service"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-injector"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -1708,11 +1708,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-macros"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "sdp-test-macros"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "secrecy"

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.2.0"
+version: "1.2.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.0"
+appVersion: "1.2.1"

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.2.0"
+version: "1.2.1"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
-appVersion: "1.2.0"
+appVersion: "1.2.1"

--- a/sdp-common/Cargo.toml
+++ b/sdp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-common"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/Cargo.toml
+++ b/sdp-identity-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-identity-service"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/src/identity_creator.rs
+++ b/sdp-identity-service/src/identity_creator.rs
@@ -176,6 +176,7 @@ impl IdentityCreator {
                 .update_secrets_fields(
                     self.secrets_api(SDP_K8S_NAMESPACE),
                     IDENTITY_MANAGER_SECRET_NAME,
+                    false,
                 )
                 .await
                 .map_err(|e| IdentityServiceError::from(e.to_string()))
@@ -518,7 +519,11 @@ impl IdentityCreator {
                         service_user.id
                     );
                     if let Err(e) = service_user
-                        .create_secrets(self.secrets_api(&service_ns), &service_ns, &service_name)
+                        .create_or_update_secrets(
+                            self.secrets_api(&service_ns),
+                            &service_ns,
+                            &service_name,
+                        )
                         .await
                     {
                         error!(

--- a/sdp-injector/Cargo.toml
+++ b/sdp-injector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-injector"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-macros/Cargo.toml
+++ b/sdp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-macros"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-test-macros/Cargo.toml
+++ b/sdp-test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-test-macros"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tools/bump-version.sh
+++ b/tools/bump-version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-RS="sdp-common sdp-device-id-service sdp-identity-service sdp-injector sdp-macros sdp-proc-macros sdp-test-macros"
+RS="sdp-common sdp-identity-service sdp-injector sdp-macros sdp-test-macros"
 HS="k8s/crd k8s/chart"
 
 bump_version() {


### PR DESCRIPTION
## Description

On startup cleanup the secrets for orphan ServiceIdentities were not deleted if the user in sdp did not exit. This PR fixes that.

It also fixes the case when old client secrets were not updated. 

## Checklist
- [X] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [X] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
