### PR TITLE
Fix prefix_name in SDPUser to support old user names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-common"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "chrono",
  "const_format",
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-identity-service"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "async-trait",
  "clap",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-injector"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "async-trait",
  "futures",
@@ -1708,11 +1708,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-macros"
-version = "1.2.1"
+version = "1.2.2"
 
 [[package]]
 name = "sdp-test-macros"
-version = "1.2.1"
+version = "1.2.2"
 
 [[package]]
 name = "secrecy"

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.2.1"
+version: "1.2.2"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.1"
+appVersion: "1.2.2"

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.2.1"
+version: "1.2.2"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
-appVersion: "1.2.1"
+appVersion: "1.2.2"

--- a/sdp-common/Cargo.toml
+++ b/sdp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-common"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-common/src/kubernetes.rs
+++ b/sdp-common/src/kubernetes.rs
@@ -63,7 +63,7 @@ impl Named for Pod {
             })
             .map(|(name, n)| {
                 let xs: Vec<&str> = name.split("-").collect();
-                let n = xs.len() - n;
+                let n: usize = xs.len() - n;
                 xs[0..n].join("-")
             });
         match maybe_name {

--- a/sdp-identity-service/Cargo.toml
+++ b/sdp-identity-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-identity-service"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/src/identity_creator.rs
+++ b/sdp-identity-service/src/identity_creator.rs
@@ -205,7 +205,7 @@ impl IdentityCreator {
             "Deleting SDPUser and associated device ids {} (id: {})",
             sdp_user.name, sdp_user.id
         );
-        let user_name = sdp_user.prefix_name().unwrap_or(sdp_user.name);
+        let user_name = sdp_user.prefix_name();
         if let Err(e) = self
             .system
             .unregister_device_ids_for_username(&user_name, None)
@@ -213,7 +213,7 @@ impl IdentityCreator {
         {
             error!(
                 "[{}] Unable to unregister device ids: {}",
-                user_name,
+                &user_name,
                 e.to_string()
             );
         }
@@ -568,8 +568,7 @@ impl IdentityCreator {
                     for sdp_user in &sdp_users {
                         let sdp_user_name =
                             SDPUser::new(sdp_user.clone(), Some(sdp_user.clone()), Some(false))
-                                .prefix_name()
-                                .unwrap_or(sdp_user.to_string());
+                                .prefix_name();
                         info!("[{}] Reconciling SDPUser", &sdp_user);
                         if let Err(e) = self
                             .system

--- a/sdp-injector/Cargo.toml
+++ b/sdp-injector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-injector"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-macros/Cargo.toml
+++ b/sdp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-macros"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-test-macros/Cargo.toml
+++ b/sdp-test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-test-macros"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Description

New versions of the injector add a random suffix to user names to avoid conflicts but old versions didn't do that. We need to support also users created by old versions during upgrade so the function needs to be compatible with both schemas

## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
