### PR TITLE
Fix pod service id discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-common"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "chrono",
  "const_format",
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-identity-service"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "async-trait",
  "clap",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-injector"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "async-trait",
  "futures",
@@ -1708,11 +1708,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-macros"
-version = "1.2.2"
+version = "1.2.3"
 
 [[package]]
 name = "sdp-test-macros"
-version = "1.2.2"
+version = "1.2.3"
 
 [[package]]
 name = "secrecy"

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.2.2"
+version: "1.2.3"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.2"
+appVersion: "1.2.3"

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.2.2"
+version: "1.2.3"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
-appVersion: "1.2.2"
+appVersion: "1.2.3"

--- a/sdp-common/Cargo.toml
+++ b/sdp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-common"
-version = "1.2.2"
+version = "1.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-common/src/annotations.rs
+++ b/sdp-common/src/annotations.rs
@@ -22,6 +22,7 @@ macro_rules! patch_annotation {
     }};
 }
 
+pub const SDP_INJECTOR_ANNOTATION_SERVICE_ID: &str = appgate_annotate!("service-id");
 pub const SDP_INJECTOR_ANNOTATION_STRATEGY: &str = appgate_annotate!("strategy");
 pub const SDP_INJECTOR_ANNOTATION_ENABLED: &str = appgate_annotate!("enabled");
 pub const SDP_INJECTOR_ANNOTATION_CLIENT_VERSION: &str = appgate_annotate!("client-version");

--- a/sdp-common/src/annotations.rs
+++ b/sdp-common/src/annotations.rs
@@ -23,6 +23,8 @@ macro_rules! patch_annotation {
 }
 
 pub const SDP_INJECTOR_ANNOTATION_SERVICE_ID: &str = appgate_annotate!("service-id");
+pub const SDP_INJECTOR_ANNOTATION_SERVICE_NAME: &str = appgate_annotate!("service-name");
+pub const SDP_INJECTOR_ANNOTATION_POD_NAME: &str = appgate_annotate!("pod-name");
 pub const SDP_INJECTOR_ANNOTATION_STRATEGY: &str = appgate_annotate!("strategy");
 pub const SDP_INJECTOR_ANNOTATION_ENABLED: &str = appgate_annotate!("enabled");
 pub const SDP_INJECTOR_ANNOTATION_CLIENT_VERSION: &str = appgate_annotate!("client-version");

--- a/sdp-common/src/kubernetes.rs
+++ b/sdp-common/src/kubernetes.rs
@@ -9,7 +9,7 @@ use kube::{core::admission::AdmissionRequest, Client, Config, Resource, Resource
 use log::error;
 
 use crate::{
-    annotations::SDP_INJECTOR_ANNOTATION_SERVICE_ID,
+    annotations::SDP_INJECTOR_ANNOTATION_POD_NAME,
     errors::SDPServiceError,
     service::needs_injection,
     traits::{Annotated, Candidate, Labeled, MaybeNamespaced, MaybeService, Named, ObjectRequest},
@@ -50,7 +50,7 @@ impl Named for Pod {
          2. Check if we have a generate_name field in the metadata (replica set owner / old injectors), then use it.
          3. Return the name as it is
         */
-        self.annotation(SDP_INJECTOR_ANNOTATION_SERVICE_ID)
+        self.annotation(SDP_INJECTOR_ANNOTATION_POD_NAME)
             .map(Clone::clone)
             .unwrap_or({
                 match self.metadata.generate_name.as_ref() {
@@ -258,7 +258,7 @@ mod test {
 
     use crate::{
         annotations::{
-            SDP_INJECTOR_ANNOTATION_ENABLED, SDP_INJECTOR_ANNOTATION_SERVICE_ID,
+            SDP_INJECTOR_ANNOTATION_ENABLED, SDP_INJECTOR_ANNOTATION_POD_NAME,
             SDP_INJECTOR_ANNOTATION_STRATEGY,
         },
         traits::{Candidate, Named},
@@ -283,7 +283,7 @@ mod test {
         assert_eq!(
             &pod!(0, generate_name => Some("None".to_string()), name => Some("bat-bi".to_string()),
             annotations => vec![
-               (SDP_INJECTOR_ANNOTATION_SERVICE_ID, "bost-sei-zazpi-zortzi")
+               (SDP_INJECTOR_ANNOTATION_POD_NAME, "bost-sei-zazpi-zortzi")
             ])
             .name(),
             &"bost-sei-zazpi-zortzi"
@@ -299,7 +299,7 @@ mod test {
             &pod!(0, name => Some("bat-bi".to_string()),
                 generate_name => Some("bost-sei-zazpi-".to_string()),
                 annotations => vec![
-                   (SDP_INJECTOR_ANNOTATION_SERVICE_ID, "bost-sei-zazpi-zortzi")
+                   (SDP_INJECTOR_ANNOTATION_POD_NAME, "bost-sei-zazpi-zortzi")
                 ]
             )
             .name(),

--- a/sdp-identity-service/Cargo.toml
+++ b/sdp-identity-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-identity-service"
-version = "1.2.2"
+version = "1.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-injector/Cargo.toml
+++ b/sdp-injector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-injector"
-version = "1.2.2"
+version = "1.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-injector/src/injector.rs
+++ b/sdp-injector/src/injector.rs
@@ -23,7 +23,7 @@ use sdp_common::annotations::{
     SDP_ANNOTATION_CLIENT_CONFIG, SDP_ANNOTATION_CLIENT_DEVICE_ID, SDP_ANNOTATION_CLIENT_SECRETS,
     SDP_ANNOTATION_DNS_SEARCHES, SDP_INJECTOR_ANNOTATION_CLIENT_VERSION,
     SDP_INJECTOR_ANNOTATION_DISABLE_INIT_CONTAINERS, SDP_INJECTOR_ANNOTATION_ENABLED,
-    SDP_INJECTOR_ANNOTATION_STRATEGY,
+    SDP_INJECTOR_ANNOTATION_SERVICE_ID, SDP_INJECTOR_ANNOTATION_STRATEGY,
 };
 use sdp_common::constants::{MAX_PATCH_ATTEMPTS, SDP_DEFAULT_CLIENT_VERSION_ENV};
 use sdp_common::errors::SDPServiceError;
@@ -537,6 +537,13 @@ impl Patched for SDPPod {
                     patch_annotation!(SDP_ANNOTATION_CLIENT_DEVICE_ID)
                 ),
                 value: serde_json::to_value(&environment.client_device_id)?,
+            }));
+            patches.push(Add(AddOperation {
+                path: format!(
+                    "/metadata/annotations/{}",
+                    patch_annotation!(SDP_INJECTOR_ANNOTATION_SERVICE_ID)
+                ),
+                value: serde_json::to_value(environment.service_name.clone())?,
             }));
 
             if std::env::var(SDP_DEFAULT_CLIENT_VERSION_ENV).is_err() {

--- a/sdp-macros/Cargo.toml
+++ b/sdp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-macros"
-version = "1.2.2"
+version = "1.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-test-macros/Cargo.toml
+++ b/sdp-test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-test-macros"
-version = "1.2.2"
+version = "1.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Description

When a pod is deleted we need to release the device id it used, when a pod is injected via AdmissionRequest we also need to know the service id for it. 
In order to do that Pods implement the Named trait.

This PR simplifies how a Pod implements the Named trait:

1. On injection the injector will add 3 new annotations:
  - service-id
  - service-name
  - pod-name
3. If the pod-name annotations is present that's the pod-name for that pod to compute the service-id later
4. If it's not present (old versions of the injector) but we have a `generateName` field in the metadata, we will use that to compute the name
5. If we don't have a `generateName` field the `name` field in metadata will be used.
6. If we don't have a `name` field it will return a random name to make sure we don't match any known service


## Checklist
- [X] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [X] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
