### PR TITLE
implement a manual device id cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-common"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "chrono",
  "const_format",
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-identity-service"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "async-trait",
  "clap",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-injector"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "async-trait",
  "futures",
@@ -1708,11 +1708,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-macros"
-version = "1.2.3"
+version = "1.2.4"
 
 [[package]]
 name = "sdp-test-macros"
-version = "1.2.3"
+version = "1.2.4"
 
 [[package]]
 name = "secrecy"

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.2.3"
+version: "1.2.4"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.3"
+appVersion: "1.2.4"

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.2.3"
+version: "1.2.4"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
-appVersion: "1.2.3"
+appVersion: "1.2.4"

--- a/sdp-common/Cargo.toml
+++ b/sdp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-common"
-version = "1.2.3"
+version = "1.2.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-common/Cargo.toml
+++ b/sdp-common/Cargo.toml
@@ -11,7 +11,7 @@ sdp-test-macros = { path = "../sdp-test-macros" }
 
 serde_json = "1.0"
 tokio = { version = "~1.34.0", features = ["rt", "macros", "rt-multi-thread"] }
-chrono = { version = "0.4.31", features = ["serde"] }
+chrono = { version = "~0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 kube = { version = "0.87.1", default-features = false, features = ["admission", "rustls-tls", "derive", "client", "runtime"] }
 k8s-openapi = { version = "0.20.0", features = ["latest"]}

--- a/sdp-identity-service/Cargo.toml
+++ b/sdp-identity-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-identity-service"
-version = "1.2.3"
+version = "1.2.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/src/identity_creator.rs
+++ b/sdp-identity-service/src/identity_creator.rs
@@ -208,7 +208,7 @@ impl IdentityCreator {
         let user_name = sdp_user.prefix_name();
         if let Err(e) = self
             .system
-            .unregister_device_ids_for_username(&user_name, None, None)
+            .unregister_device_ids_for_username(&user_name, None, None, false)
             .await
         {
             error!(
@@ -576,6 +576,7 @@ impl IdentityCreator {
                                 &sdp_user_name,
                                 Some(&sdp_users),
                                 None,
+                                false,
                             )
                             .await
                         {
@@ -592,6 +593,7 @@ impl IdentityCreator {
                         .unregister_device_id_for_user(
                             &SDPUser::new(service_user.id, Some(service_user.name.clone()), None),
                             &device_id,
+                            false,
                         )
                         .await
                     {

--- a/sdp-identity-service/src/identity_creator.rs
+++ b/sdp-identity-service/src/identity_creator.rs
@@ -208,7 +208,7 @@ impl IdentityCreator {
         let user_name = sdp_user.prefix_name();
         if let Err(e) = self
             .system
-            .unregister_device_ids_for_username(&user_name, None)
+            .unregister_device_ids_for_username(&user_name, None, None)
             .await
         {
             error!(
@@ -572,7 +572,11 @@ impl IdentityCreator {
                         info!("[{}] Reconciling SDPUser", &sdp_user);
                         if let Err(e) = self
                             .system
-                            .unregister_device_ids_for_username(&sdp_user_name, Some(&sdp_users))
+                            .unregister_device_ids_for_username(
+                                &sdp_user_name,
+                                Some(&sdp_users),
+                                None,
+                            )
                             .await
                         {
                             error!(

--- a/sdp-identity-service/src/main.rs
+++ b/sdp-identity-service/src/main.rs
@@ -36,10 +36,10 @@ fn show_crds() {
     println!("{}", p.unwrap());
 }
 
-async fn release_device_ids(user_name: String, since: Duration) {
+async fn release_device_ids(user_name: String, since: Duration, dry_run: bool) {
     let mut sdp_client = get_sdp_system();
     if let Err(e) = sdp_client
-        .unregister_device_ids_for_username(&user_name, None, Some(since))
+        .unregister_device_ids_for_username(&user_name, None, Some(since), dry_run)
         .await
     {
         error!(
@@ -67,6 +67,8 @@ struct DeviceIdsArgs {
     user_name: String,
     #[arg(value_parser = parse_seconds)]
     since: Duration,
+    #[arg(long = "dry-run")]
+    dry_run: bool,
 }
 
 fn parse_seconds(arg: &str) -> Result<std::time::Duration, std::num::ParseIntError> {
@@ -97,7 +99,7 @@ async fn main() -> () {
             show_crds();
         }
         IdentityServiceCommands::DeviceIds(args) => {
-            release_device_ids(args.user_name, args.since).await;
+            release_device_ids(args.user_name, args.since, args.dry_run).await;
         }
         IdentityServiceCommands::Run => {
             let client = get_k8s_client().await;

--- a/sdp-injector/Cargo.toml
+++ b/sdp-injector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-injector"
-version = "1.2.3"
+version = "1.2.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-macros/Cargo.toml
+++ b/sdp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-macros"
-version = "1.2.3"
+version = "1.2.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-test-macros/Cargo.toml
+++ b/sdp-test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-test-macros"
-version = "1.2.3"
+version = "1.2.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Description

With this cli we can unregister onboarded users.

```SDP_SYSTEM_HOSTS=https://controller.example.com8443 SDP_K8S_USERNAME=admin SDP_K8S_PASSWORD=admin SDP_K8S_PROVIDER=local SDP_CLUSTER_ID=my-cluster sdp-identity-service device-ids my_cluster_ $(($(date +'%s') - $((8 * $((3600 * 24)))))) --dry-run````

## Checklist
- [X] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [X] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
