### PR TITLE
[SA-23951] Fix Accept and User Agent headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-common"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "chrono",
  "const_format",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-identity-service"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "clap",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-injector"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "futures",
@@ -1763,11 +1763,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-macros"
-version = "1.3.1"
+version = "1.3.2"
 
 [[package]]
 name = "sdp-test-macros"
-version = "1.3.1"
+version = "1.3.2"
 
 [[package]]
 name = "secrecy"

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.3.1"
+version: "1.3.2"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.1"
+appVersion: "1.3.2"

--- a/k8s/chart/templates/sdp-identity-service.yaml
+++ b/k8s/chart/templates/sdp-identity-service.yaml
@@ -96,7 +96,7 @@ spec:
                   name: {{ required ".Values.sdp.metaClient.adminSecret is required" .Values.sdp.metaClient.adminSecret }}
                   key: sdp-injector-mc-profile-url
         - name: {{ .Chart.Name }}-sdp-driver
-          image: {{ default .Values.global.image.repository .Values.sdp.headlessDriver.image.repository }}/sdp-headless-driver:{{ default .Values.sdp.clientVersion  .Values.sdp.headlessService.image.tag }}
+          image: {{ default .Values.global.image.repository .Values.sdp.headlessDriver.image.repository }}/sdp-headless-driver:{{ default .Values.sdp.clientVersion  .Values.sdp.headlessDriver.image.tag }}
           imagePullPolicy: {{ .Values.sdp.headlessDriver.image.pullPolicy }}
           securityContext:
             runAsGroup: 101
@@ -112,7 +112,7 @@ spec:
             - mountPath: /dev/net/tun
               name: tun-device
         - name: {{ .Chart.Name }}-sdp-dnsmasq
-          image: "{{ default .Values.global.image.repository .Values.sdp.dnsmasq.image.repository }}/sdp-dnsmasq:{{ default .Values.sdp.clientVersion  .Values.sdp.headlessService.image.tag }}"
+          image: "{{ default .Values.global.image.repository .Values.sdp.dnsmasq.image.repository }}/sdp-dnsmasq:{{ default .Values.sdp.clientVersion  .Values.sdp.dnsmasq.image.tag }}"
           imagePullPolicy: {{ .Values.sdp.dnsmasq.image.pullPolicy }}
           securityContext:
             runAsGroup: 101

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.3.1"
+version: "1.3.2"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
-appVersion: "1.3.1"
+appVersion: "1.3.2"

--- a/sdp-common/Cargo.toml
+++ b/sdp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-common"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-common/src/sdp/system.rs
+++ b/sdp-common/src/sdp/system.rs
@@ -120,8 +120,8 @@ impl SystemConfig {
         match client.get(url).headers(headers).send().await {
             Ok(response) => {
                 if response.status() == 406 {
-                    let my_response: InvalidHeaderResponse = response.json().await.expect("Expect response");
-                    self.api_version = Some(my_response.max_supported_version.to_string());
+                    let response: InvalidHeaderResponse = response.json().await.expect("Expect response");
+                    self.api_version = Some(response.max_supported_version.to_string());
                 }
             }
             Err(e) => {

--- a/sdp-common/src/sdp/system.rs
+++ b/sdp-common/src/sdp/system.rs
@@ -10,11 +10,11 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::time::Duration;
+use serde_json::Value;
 use uuid::Uuid;
 
 const SDP_SYSTEM_HOSTS: &str = "SDP_SYSTEM_HOSTS";
 const SDP_SYSTEM_NO_VERIFY_ENV: &str = "SDP_SYSTEM_NO_VERIFY";
-const SDP_SYSTEM_API_VERSION: &str = "v17";
 const SDP_SYSTEM_USERNAME: &str = "SDP_K8S_USERNAME";
 const SDP_SYSTEM_USERNAME_DEFAULT: &str = "admin";
 const SDP_SYSTEM_PASSWORD_ENV: &str = "SDP_K8S_PASSWORD";
@@ -38,7 +38,7 @@ pub struct OnBoardedUser {
     pub last_seen_at: DateTime<Utc>,
 }
 
-pub fn get_sdp_system() -> System {
+pub async fn get_sdp_system() -> System {
     let hosts = std::env::var(SDP_SYSTEM_HOSTS)
         .map(|vs| {
             vs.split(",")
@@ -58,7 +58,7 @@ pub fn get_sdp_system() -> System {
     };
 
     SystemConfig::new(hosts)
-        .with_api_version(SDP_SYSTEM_API_VERSION)
+        .fix_api_version().await
         .build(credentials)
         .expect("Unable to create SDP client")
 }
@@ -68,6 +68,15 @@ pub struct SystemConfig {
     pub hosts: Vec<Url>,
     pub api_version: Option<String>,
     pub credentials: Option<Credentials>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct InvalidHeaderResponse {
+    message: String,
+    max_supported_version: u16,
+    min_supported_version: u16,
+    id: String
 }
 
 impl SystemConfig {
@@ -85,19 +94,36 @@ impl SystemConfig {
             .api_version
             .as_ref()
             .map(|v| v.as_str())
-            .unwrap_or(SDP_SYSTEM_API_VERSION);
+            .expect("Expected API version to be set for application/vnd.appgate.peer header");
         let header_value = format!("application/vnd.appgate.peer-v{}+json", api_version);
         hm.append(ACCEPT, HeaderValue::from_str(&header_value)?);
         Ok(hm)
     }
 
-    pub fn with_api_version(&mut self, _: &str) -> &mut SystemConfig {
-        let api_version = self
-            .api_version
-            .as_ref()
-            .map(|v| v.as_str())
-            .unwrap_or("17");
-        self.api_version = Some(api_version.to_string());
+    pub async fn fix_api_version(&mut self) -> &mut SystemConfig {
+        let no_verify = match std::env::var(SDP_SYSTEM_NO_VERIFY_ENV) {
+            Ok(v) if v == "1" || v.to_lowercase() == "true" => true,
+            _ => false,
+        };
+        let client = Client::builder()
+            .danger_accept_invalid_certs(no_verify)
+            .build()
+            .expect("Failed to build HTTP client");
+        let mut url = Url::from(self.hosts[0].clone());
+        url.set_path("/admin/identity-providers/names");
+        let mut headers = HeaderMap::new();
+        headers.insert(ACCEPT, HeaderValue::from_static("application/vnd.appgate.peer-v0+json"));
+        match client.get(url).headers(headers).send().await {
+            Ok(response) => {
+                if response.status() == 406 {
+                    let my_response: InvalidHeaderResponse = response.json().await.expect("Expect response");
+                    self.api_version = Some(my_response.max_supported_version.to_string());
+                }
+            }
+            Err(e) => {
+                info!("Failed to get API version to fix Accept header: {}", e);
+            }
+        }
         self
     }
 

--- a/sdp-common/src/sdp/system.rs
+++ b/sdp-common/src/sdp/system.rs
@@ -5,12 +5,11 @@ use http::header::{InvalidHeaderValue, ACCEPT};
 use http::{HeaderValue, StatusCode};
 use reqwest::header::HeaderMap;
 use reqwest::{Client, Url};
-use sdp_macros::{logger, sdp_info, sdp_log, with_dollar_sign};
+use sdp_macros::{logger, sdp_info, sdp_error, sdp_log, with_dollar_sign};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::time::Duration;
-use serde_json::Value;
 use uuid::Uuid;
 
 const SDP_SYSTEM_HOSTS: &str = "SDP_SYSTEM_HOSTS";
@@ -125,7 +124,7 @@ impl SystemConfig {
                 }
             }
             Err(e) => {
-                info!("Failed to get API version to fix Accept header: {}", e);
+                error!("Failed to get API version to fix Accept header: {}", e);
             }
         }
         self

--- a/sdp-common/src/sdp/system.rs
+++ b/sdp-common/src/sdp/system.rs
@@ -22,6 +22,10 @@ const SDP_SYSTEM_PASSWORD_DEFAULT: &str = "admin";
 const SDP_SYSTEM_PROVIDER_ENV: &str = "SDP_K8S_PROVIDER";
 const SDP_SYSTEM_PROVIDER_DEFAULT: &str = "local";
 
+static APP_USER_AGENT: &str = concat!(
+env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),
+);
+
 logger!("SDPSystem");
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -138,6 +142,7 @@ impl SystemConfig {
         Client::builder()
             .default_headers(hm)
             .danger_accept_invalid_certs(no_verify)
+            .user_agent(APP_USER_AGENT)
             .build()
             .map_err(|e| format!("Unable to create SDP client: {}", e))
             .map(|c| System {

--- a/sdp-identity-service/Cargo.toml
+++ b/sdp-identity-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-identity-service"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/src/main.rs
+++ b/sdp-identity-service/src/main.rs
@@ -37,7 +37,7 @@ fn show_crds() {
 }
 
 async fn release_device_ids(user_name: String, since: Duration, dry_run: bool, exact_match: bool) {
-    let mut sdp_client = get_sdp_system();
+    let mut sdp_client = get_sdp_system().await;
     let mut hs: Option<HashSet<String>> = None;
     if exact_match {
         hs = Some(HashSet::from_iter(vec![user_name.to_string()]));
@@ -203,10 +203,10 @@ async fn main() -> () {
             });
 
             tokio::spawn(async move {
-                let system = get_sdp_system();
+                let system = get_sdp_system().await;
                 let identity_creator =
                     IdentityCreator::new(system, identity_creator_client, CREDENTIALS_POOL_SIZE);
-                let mut system2 = get_sdp_system();
+                let mut system2 = get_sdp_system().await;
                 identity_creator
                     .run(
                         &mut system2,

--- a/sdp-injector/Cargo.toml
+++ b/sdp-injector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-injector"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-injector/src/main.rs
+++ b/sdp-injector/src/main.rs
@@ -140,7 +140,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Spawn the DeviceIdProvider
     tokio::spawn(async move {
         let mut device_id_provider = DeviceIdProvider::new(None);
-        let sdp_system = get_sdp_system();
+        let sdp_system = get_sdp_system().await;
         device_id_provider
             .run(device_id_rx, watcher_rx, sdp_system)
             .await;

--- a/sdp-macros/Cargo.toml
+++ b/sdp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-macros"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-test-macros/Cargo.toml
+++ b/sdp-test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-test-macros"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Description
* Remove hard-coded API version with the good ol' 406 hack
* Add the User Agent header so it doesn't show up as `null` on the controller

## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
