### PR TITLE
Make sdp client optional in the injector service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-common"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "chrono",
  "const_format",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-identity-service"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "async-trait",
  "clap",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-injector"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "async-trait",
  "futures",
@@ -1763,11 +1763,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-macros"
-version = "1.3.3"
+version = "1.3.4"
 
 [[package]]
 name = "sdp-test-macros"
-version = "1.3.3"
+version = "1.3.4"
 
 [[package]]
 name = "secrecy"

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.3.3"
+version: "1.3.4"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.3"
+appVersion: "1.3.4"

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.3.3"
+version: "1.3.4"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
-appVersion: "1.3.3"
+appVersion: "1.3.4"

--- a/sdp-common/Cargo.toml
+++ b/sdp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-common"
-version = "1.3.3"
+version = "1.3.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-common/src/sdp/system.rs
+++ b/sdp-common/src/sdp/system.rs
@@ -75,10 +75,10 @@ pub struct SystemConfig {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 struct InvalidHeaderResponse {
-    message: String,
+    _message: String,
     max_supported_version: u16,
-    min_supported_version: u16,
-    id: String
+    _min_supported_version: u16,
+    _id: String,
 }
 
 impl SystemConfig {

--- a/sdp-common/src/sdp/system.rs
+++ b/sdp-common/src/sdp/system.rs
@@ -5,7 +5,7 @@ use http::header::{InvalidHeaderValue, ACCEPT};
 use http::{HeaderValue, StatusCode};
 use reqwest::header::HeaderMap;
 use reqwest::{Client, Url};
-use sdp_macros::{logger, sdp_info, sdp_error, sdp_log, with_dollar_sign};
+use sdp_macros::{logger, sdp_error, sdp_info, sdp_log, with_dollar_sign};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -21,9 +21,7 @@ const SDP_SYSTEM_PASSWORD_DEFAULT: &str = "admin";
 const SDP_SYSTEM_PROVIDER_ENV: &str = "SDP_K8S_PROVIDER";
 const SDP_SYSTEM_PROVIDER_DEFAULT: &str = "local";
 
-static APP_USER_AGENT: &str = concat!(
-env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),
-);
+static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
 logger!("SDPSystem");
 
@@ -61,7 +59,8 @@ pub async fn get_sdp_system() -> System {
     };
 
     SystemConfig::new(hosts)
-        .fix_api_version().await
+        .fix_api_version()
+        .await
         .build(credentials)
         .expect("Unable to create SDP client")
 }
@@ -115,11 +114,15 @@ impl SystemConfig {
         let mut url = Url::from(self.hosts[0].clone());
         url.set_path("/admin/identity-providers/names");
         let mut headers = HeaderMap::new();
-        headers.insert(ACCEPT, HeaderValue::from_static("application/vnd.appgate.peer-v0+json"));
+        headers.insert(
+            ACCEPT,
+            HeaderValue::from_static("application/vnd.appgate.peer-v0+json"),
+        );
         match client.get(url).headers(headers).send().await {
             Ok(response) => {
                 if response.status() == 406 {
-                    let response: InvalidHeaderResponse = response.json().await.expect("Expect response");
+                    let response: InvalidHeaderResponse =
+                        response.json().await.expect("Expect response");
                     self.api_version = Some(response.max_supported_version.to_string());
                 }
             }

--- a/sdp-identity-service/Cargo.toml
+++ b/sdp-identity-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-identity-service"
-version = "1.3.3"
+version = "1.3.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/src/identity_manager.rs
+++ b/sdp-identity-service/src/identity_manager.rs
@@ -99,10 +99,6 @@ trait ServiceIdentityAPI<'a> {
     ) -> Result<ServiceIdentity, IdentityServiceError>;
     async fn delete(&self, identity: &'a ServiceIdentity) -> Result<(), IdentityServiceError>;
     async fn list(&self) -> Result<Vec<ServiceIdentity>, IdentityServiceError>;
-    async fn get(
-        &self,
-        identity: &'a ServiceIdentity,
-    ) -> Result<Option<ServiceIdentity>, IdentityServiceError>;
 }
 
 /*
@@ -304,14 +300,6 @@ impl<'a> ServiceIdentityAPI<'a> for IdentityManagerServiceIdentityAPI {
             .map(|xs| xs.items)
             .map_err(IdentityServiceError::from)
     }
-
-    async fn get(
-        &self,
-        identity: &'a ServiceIdentity,
-    ) -> Result<Option<ServiceIdentity>, IdentityServiceError> {
-        let identity = self.api.get_opt(&identity.service_name()).await?;
-        Ok(identity)
-    }
 }
 
 type IdentityCreatorProtocolSender = Sender<IdentityCreatorProtocol>;
@@ -392,13 +380,6 @@ impl<'a> ServiceIdentityAPI<'a> for IdentityManager<'a> {
 
     async fn list(&self) -> Result<Vec<ServiceIdentity>, IdentityServiceError> {
         self.service_identity_api.list().await
-    }
-
-    async fn get(
-        &self,
-        identity: &'a ServiceIdentity,
-    ) -> Result<Option<ServiceIdentity>, IdentityServiceError> {
-        self.get(identity).await
     }
 }
 
@@ -1060,7 +1041,6 @@ mod tests {
         create_calls: Arc<RwLock<usize>>,
         list_calls: Arc<RwLock<usize>>,
         update_calls: Arc<RwLock<usize>>,
-        get_calls: Arc<RwLock<usize>>,
     }
 
     struct TestIdentityManager {
@@ -1101,15 +1081,6 @@ mod tests {
             let mut c = self.update_calls.write().await;
             *c += 1;
             Ok(identity.clone())
-        }
-
-        async fn get(
-            &self,
-            identity: &'a ServiceIdentity,
-        ) -> Result<Option<ServiceIdentity>, IdentityServiceError> {
-            let mut c = self.get_calls.write().await;
-            *c += 1;
-            Ok(Some(identity.clone()))
         }
     }
 

--- a/sdp-injector/Cargo.toml
+++ b/sdp-injector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-injector"
-version = "1.3.3"
+version = "1.3.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-injector/src/main.rs
+++ b/sdp-injector/src/main.rs
@@ -17,7 +17,6 @@ use hyper::Server;
 use kube::{Api, Client, Config};
 use sdp_common::crd::ServiceIdentity;
 use sdp_common::kubernetes::{KUBE_SYSTEM_NAMESPACE, SDP_K8S_NAMESPACE};
-use sdp_common::sdp::system::get_sdp_system;
 use sdp_common::service::get_log_config_path;
 use sdp_common::watcher::{watch, Watcher};
 use sdp_macros::{logger, sdp_debug, sdp_error, sdp_info, sdp_log, sdp_warn, with_dollar_sign};
@@ -140,10 +139,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Spawn the DeviceIdProvider
     tokio::spawn(async move {
         let mut device_id_provider = DeviceIdProvider::new(None);
-        let sdp_system = get_sdp_system().await;
-        device_id_provider
-            .run(device_id_rx, watcher_rx, sdp_system)
-            .await;
+        // TODO: Once the services are merged we should pass an SDP Client here and make it mandatory
+        device_id_provider.run(device_id_rx, watcher_rx, None).await;
     });
 
     info!("Starting SDP Injector server");

--- a/sdp-macros/Cargo.toml
+++ b/sdp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-macros"
-version = "1.3.3"
+version = "1.3.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-test-macros/Cargo.toml
+++ b/sdp-test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-test-macros"
-version = "1.3.3"
+version = "1.3.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Description

Make the SDP Client in the injector optional so it's more clear that we don't want to use it there. https://github.com/appgate/sdp-k8s-injector/pull/255 this PR made the injector to need a metaclient to be able to reach controllers behind SDP appgate.


## Checklist
- [X] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [X] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
