### PR TITLE
Bookworm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-common"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "chrono",
  "const_format",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-identity-service"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "async-trait",
  "clap",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-injector"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "async-trait",
  "futures",
@@ -1763,11 +1763,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-macros"
-version = "1.3.4"
+version = "1.3.5"
 
 [[package]]
 name = "sdp-test-macros"
-version = "1.3.4"
+version = "1.3.5"
 
 [[package]]
 name = "secrecy"

--- a/docker/sdp-dnsmasq-Dockerfile
+++ b/docker/sdp-dnsmasq-Dockerfile
@@ -22,7 +22,7 @@ COPY assets/sdp-dnsmasq-set-dns /sdp-dnsmasq/sdp-dnsmasq-set-dns
 COPY assets/wait-for-stop /sdp-dnsmasq/wait-for-stop
 RUN mkdir /var/run/sdp-dnsmasq && \
     mkdir -p /sdp-dnsmasq/dnsmasq.d && \
-    chown 100:101 /var/run/sdp-dnsmasq -R && \
+    chown 105:101 /var/run/sdp-dnsmasq -R && \
     chmod g+w /var/run/sdp-dnsmasq && \
     chown 105:101 /sdp-dnsmasq/ -R && \
     chmod +x /sdp-dnsmasq/sdp-dnsmasq && \

--- a/docker/sdp-dnsmasq-Dockerfile
+++ b/docker/sdp-dnsmasq-Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir /var/run/sdp-dnsmasq && \
     mkdir -p /sdp-dnsmasq/dnsmasq.d && \
     chown 100:101 /var/run/sdp-dnsmasq -R && \
     chmod g+w /var/run/sdp-dnsmasq && \
-    chown 100:101 /sdp-dnsmasq/ -R && \
+    chown 105:101 /sdp-dnsmasq/ -R && \
     chmod +x /sdp-dnsmasq/sdp-dnsmasq && \
     chmod +x /sdp-dnsmasq/wait-for-stop
 WORKDIR /sdp-dnsmasq

--- a/docker/sdp-headless-driver-Dockerfile
+++ b/docker/sdp-headless-driver-Dockerfile
@@ -13,7 +13,7 @@ RUN curl "https://bin.appgate-sdp.com/latest/client.json" --output "/tmp/latest.
 ARG QUERY='.releases.'\"${CLIENT_VERSION}\"'[] | select(.os == "ubuntu" and .type == "headless") | .link'
 RUN curl $(jq "${QUERY}" /tmp/latest.json --raw-output) --output "/tmp/${CLIENT_DEB}"
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 LABEL sdp=true
 LABEL project=sdp-client-headless
 ARG CLIENT_DEB

--- a/docker/sdp-headless-driver-Dockerfile
+++ b/docker/sdp-headless-driver-Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get install -y \
     groupmod -g 103 messagebus && \
     addgroup dnsmasq --gid 101 && \
     usermod _apt -u 104 && \
-    usermod dnsmasq -u 100 -g 101 && \
+    usermod dnsmasq -u 105 -g 101 && \
     usermod appgate -a -G dnsmasq
 
 RUN apt-get update && \

--- a/docker/sdp-headless-service-Dockerfile
+++ b/docker/sdp-headless-service-Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y \
     groupmod -g 103 messagebus && \
     addgroup dnsmasq --gid 101 && \
     usermod _apt -u 104 && \
-    usermod dnsmasq -u 100 -g 101 && \
+    usermod dnsmasq -u 105 -g 101 && \
     usermod  appgate -a -G dnsmasq
 
 RUN rm -rf \

--- a/docker/sdp-headless-service-Dockerfile
+++ b/docker/sdp-headless-service-Dockerfile
@@ -55,14 +55,10 @@ COPY assets/wait-for-stop /opt/appgate/wait-for-stop
 RUN chmod +x /opt/appgate/sdp-client-headless-service && \
     touch /etc/machine-id && \
     chown 103:102 /etc/machine-id && \
-    mkdir /sdp-service && \
-    mkdir /var/run/appgate && \
-    mkdir /var/run/sdp-service && \
-    chown 103:102 /sdp-service && \
-    chown 103:101 /var/run/sdp-service -R && \
-    chown 103:102 /var/run/appgate && \
-    mkdir -p /var/log/appgate && \
-    chown -R 103:102 /var/log/appgate && \
+    mkdir /sdp-service && chown 103:102 /sdp-service && \
+    mkdir /var/run/appgate && chown 103:102 /var/run/appgate && \
+    mkdir /var/run/sdp-service && chown 103:101 /var/run/sdp-service -R && \
+    mkdir -p /var/log/appgate && chown -R 103:102 /var/log/appgate && \
     mkdir -p /.local/share/appgatesdp-service/ && chown -R 103:102 /.local/share/appgatesdp-service/ && \
     mkdir -p /.config/appgatesdp-service/ && chown -R 103:102 /.config/appgatesdp-service/ && \
     chmod +x /opt/appgate/pod_info && \

--- a/docker/sdp-headless-service-Dockerfile
+++ b/docker/sdp-headless-service-Dockerfile
@@ -13,7 +13,7 @@ RUN curl "https://bin.appgate-sdp.com/latest/client.json" --output "/tmp/latest.
 ARG QUERY='.releases.'\"${CLIENT_VERSION}\"'[] | select(.os == "ubuntu" and .type == "headless") | .link'
 RUN curl $(jq "${QUERY}" /tmp/latest.json --raw-output) --output "/tmp/${CLIENT_DEB}"
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 LABEL sdp=true
 LABEL project=sdp-client-headless
 ARG CLIENT_DEB

--- a/docker/sdp-headless-service-Dockerfile
+++ b/docker/sdp-headless-service-Dockerfile
@@ -63,6 +63,8 @@ RUN chmod +x /opt/appgate/sdp-client-headless-service && \
     chown 103:102 /var/run/appgate && \
     mkdir -p /var/log/appgate && \
     chown -R 103:102 /var/log/appgate && \
+    mkdir -p /.local/share/appgatesdp-service/ && chown -R 103:102 /.local/share/appgatesdp-service/ && \
+    mkdir -p /.config/appgatesdp-service/ && chown -R 103:102 /.config/appgatesdp-service/ && \
     chmod +x /opt/appgate/pod_info && \
     chmod +x /opt/appgate/sdp-service-probe && \
     chmod +x /opt/appgate/sdp-service-watcher && \

--- a/docker/sdp-headless-service-Dockerfile
+++ b/docker/sdp-headless-service-Dockerfile
@@ -58,7 +58,7 @@ RUN chmod +x /opt/appgate/sdp-client-headless-service && \
     mkdir /sdp-service && chown 103:102 /sdp-service && \
     mkdir /var/run/appgate && chown 103:102 /var/run/appgate && \
     mkdir /var/run/sdp-service && chown 103:101 /var/run/sdp-service -R && \
-    mkdir -p /var/log/appgate && chown -R 103:102 /var/log/appgate && \
+    mkdir -p /var/log/appgate-headless && chown -R 103:102 /var/log/appgate-headless && \
     mkdir -p /.local/share/appgatesdp-service/ && chown -R 103:102 /.local/share/appgatesdp-service/ && \
     mkdir -p /.config/appgatesdp-service/ && chown -R 103:102 /.config/appgatesdp-service/ && \
     chmod +x /opt/appgate/pod_info && \

--- a/docker/sdp-k8s-injector-Dockerfile
+++ b/docker/sdp-k8s-injector-Dockerfile
@@ -32,7 +32,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=k8s-injector-registry
     cargo chef cook $([ "$PROFILE" = "release" ] && echo --release) --recipe-path recipe.json && \
     ls -la /sdp-build/target > /sdp-build/out
 
-FROM rust:${RUST_VERSION}-slim-bullseye
+FROM rust:${RUST_VERSION}-slim-bookworm
 LABEL sdp=true
 LABEL project=sdp-k8s-injector
 LABEL image=sdp-k8s-injector-build

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.3.4"
+version: "1.3.5"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.4"
+appVersion: "1.3.5"

--- a/k8s/chart/templates/configmap-sidecar.yaml
+++ b/k8s/chart/templates/configmap-sidecar.yaml
@@ -120,7 +120,7 @@ data:
           "imagePullPolicy": "{{.Values.sdp.dnsmasq.image.pullPolicy}}",
           "securityContext": {
             "runAsGroup": 101,
-            "runAsUser": 100,
+            "runAsUser": 105,
             "runAsNonRoot": true
           },
           "volumeMounts": [

--- a/k8s/chart/templates/sdp-identity-service.yaml
+++ b/k8s/chart/templates/sdp-identity-service.yaml
@@ -116,7 +116,7 @@ spec:
           imagePullPolicy: {{ .Values.sdp.dnsmasq.image.pullPolicy }}
           securityContext:
             runAsGroup: 101
-            runAsUser: 100
+            runAsUser: 105
             runAsNonRoot: true
           env:
             - name: K8S_DNS_SERVICE

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.3.4"
+version: "1.3.5"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
-appVersion: "1.3.4"
+appVersion: "1.3.5"

--- a/sdp-common/Cargo.toml
+++ b/sdp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-common"
-version = "1.3.4"
+version = "1.3.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/Cargo.toml
+++ b/sdp-identity-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-identity-service"
-version = "1.3.4"
+version = "1.3.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/Dockerfile
+++ b/sdp-identity-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 LABEL sdp=true
 LABEL project=sdp-k8s-injector
 LABEL image=sdp-identity-service

--- a/sdp-injector/Cargo.toml
+++ b/sdp-injector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-injector"
-version = "1.3.4"
+version = "1.3.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-injector/Dockerfile
+++ b/sdp-injector/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 LABEL sdp=true
 LABEL project=sdp-k8s-injector
 LABEL image=sdp-injector

--- a/sdp-macros/Cargo.toml
+++ b/sdp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-macros"
-version = "1.3.4"
+version = "1.3.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-test-macros/Cargo.toml
+++ b/sdp-test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-test-macros"
-version = "1.3.4"
+version = "1.3.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Description
Upgrade base OS to Debian 12 (bookworm)

The existing identity-service and injector doesn't run with bookworm because the binaries are built using openssl 1.1 - bookworm dropped 1.1 and began using openssl 3. We need to change our builder OS to bookworm so the binaries are compiled using libssl3. 

Additional Changes
- Change `dnsmasq` user to UID 105 because 100 is taken by the OS. 
- Fix permission on `/var/log/appgate-headless` for sdp-identity-service.

Tested on minikube with meta-client and demo-worker
<img width="776" alt="Screenshot 2024-09-30 at 4 40 41 PM" src="https://github.com/user-attachments/assets/f06b28c3-3f9c-4163-9936-878b8d150b3b">


## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
