### PR TITLE
Logging improvements + README for Non-Deployment Injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-common"
-version = "1.3.6"
+version = "1.3.7"
 dependencies = [
  "chrono",
  "const_format",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-identity-service"
-version = "1.3.6"
+version = "1.3.7"
 dependencies = [
  "async-trait",
  "clap",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-injector"
-version = "1.3.6"
+version = "1.3.7"
 dependencies = [
  "async-trait",
  "futures",
@@ -1763,11 +1763,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-macros"
-version = "1.3.6"
+version = "1.3.7"
 
 [[package]]
 name = "sdp-test-macros"
-version = "1.3.6"
+version = "1.3.7"
 
 [[package]]
 name = "secrecy"

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ spec:
 
 Add following annotation to the podTemplate of the Replicaset. The annotation value must match the name of the SDPService 
 ```yaml
-"k8s.appgate.com/sdp-injector.pod-name" = "example-replicaset"
+"k8s.appgate.com/sdp-injector.pod-name": "example-replicaset"
 ```
 The resulting ReplicaSet definition is as follows
 ```yaml

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.3.6"
+version: "1.3.7"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.6"
+appVersion: "1.3.7"

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.3.6"
+version: "1.3.7"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
-appVersion: "1.3.6"
+appVersion: "1.3.7"

--- a/sdp-common/Cargo.toml
+++ b/sdp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-common"
-version = "1.3.6"
+version = "1.3.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-common/src/kubernetes.rs
+++ b/sdp-common/src/kubernetes.rs
@@ -68,7 +68,7 @@ impl Named for Pod {
                         }
                     }
                     None => self.metadata.name.as_ref().map(Clone::clone).unwrap_or({
-                        debug!("Unable to find service name for Pod");
+                        error!("Unable to find .metadata.name of Pod");
                         uuid::Uuid::new_v4().to_string()
                     }),
                 }

--- a/sdp-common/src/kubernetes.rs
+++ b/sdp-common/src/kubernetes.rs
@@ -6,7 +6,7 @@ use k8s_openapi::api::{
     core::v1::{Namespace, Pod},
 };
 use kube::{core::admission::AdmissionRequest, Client, Config, Resource, ResourceExt};
-use log::error;
+use log::{debug, error};
 
 use crate::{
     annotations::SDP_INJECTOR_ANNOTATION_POD_NAME,
@@ -68,7 +68,7 @@ impl Named for Pod {
                         }
                     }
                     None => self.metadata.name.as_ref().map(Clone::clone).unwrap_or({
-                        error!("Unable to find service name for Pod");
+                        debug!("Unable to find service name for Pod");
                         uuid::Uuid::new_v4().to_string()
                     }),
                 }

--- a/sdp-common/src/kubernetes.rs
+++ b/sdp-common/src/kubernetes.rs
@@ -46,7 +46,7 @@ impl Named for Pod {
     fn name(&self) -> String {
         /*
         To get the service name for a pod we do:
-         1. Check if it's in an annotation defined (added by injector). If it's tehre return it
+         1. Check if it's in an annotation defined (added by injector). If it's there, return it
          2. Check if we have a generate_name field in the metadata (replica set owner / old injectors), then use it.
          3. Return the name as it is
         */

--- a/sdp-common/src/watcher.rs
+++ b/sdp-common/src/watcher.rs
@@ -152,11 +152,11 @@ where
                 };
                 let msg = match op {
                     WatcherOperation::Apply => {
-                        info!("Sending Applied message for {}", e.name_any());
+                        debug!("Sending Applied message for {}", e.name_any());
                         e.applied(ns)
                     }
                     WatcherOperation::ReApply => {
-                        info!("Sending Reapplied message for {}", e.name_any());
+                        debug!("Sending Reapplied message for {}", e.name_any());
                         e.reapplied(ns)
                     }
                 };

--- a/sdp-identity-service/Cargo.toml
+++ b/sdp-identity-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-identity-service"
-version = "1.3.6"
+version = "1.3.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-injector/Cargo.toml
+++ b/sdp-injector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-injector"
-version = "1.3.6"
+version = "1.3.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-injector/src/injector.rs
+++ b/sdp-injector/src/injector.rs
@@ -661,7 +661,7 @@ impl Patched for SDPPod {
                 }));
             }
         }
-        debug!("Pod patches: {:?}", patches);
+        info!("Applying the following patch to the Pod: {:?}", patches);
         Ok(Patch(patches))
     }
 }

--- a/sdp-injector/src/injector.rs
+++ b/sdp-injector/src/injector.rs
@@ -266,7 +266,7 @@ async fn dns_service_discover(services_api: &Api<KubeService>) -> Option<KubeSer
                         // k8s-app label is by design: https://github.com/coredns/deployment/issues/116
                         let maybe_dns_service = l.get("k8s-app");
                         if let Some(dns) = maybe_dns_service {
-                            info!("Kubernetes DNS Service: {}", dns);
+                            debug!("Kubernetes DNS Service: {}", dns);
                         }
                         maybe_dns_service
                     })
@@ -2494,7 +2494,7 @@ pub async fn injector_handler<E: DeviceIdRequester>(
             match mutate(bs, sdp_context).await {
                 // Object properly patched and allowed
                 Ok(SDPPatchResponse::Allow(mut response)) => {
-                    info!(
+                    debug!(
                         "Resource patched with {} patches",
                         response.patch.as_ref().map(|xs| xs.len()).unwrap_or(0)
                     );

--- a/sdp-injector/src/injector.rs
+++ b/sdp-injector/src/injector.rs
@@ -2494,10 +2494,11 @@ pub async fn injector_handler<E: DeviceIdRequester>(
             match mutate(bs, sdp_context).await {
                 // Object properly patched and allowed
                 Ok(SDPPatchResponse::Allow(mut response)) => {
-                    debug!(
-                        "Resource patched with {} patches",
-                        response.patch.as_ref().map(|xs| xs.len()).unwrap_or(0)
-                    );
+                    if let Some(xs) = response.patch.as_ref() {
+                        if !xs.is_empty() {
+                            info!("Resource patched with {} patches",  xs.len());
+                        }
+                    }
                     // Object properly patched and allowed
                     allow_admission_response!(response => response)
                 }

--- a/sdp-macros/Cargo.toml
+++ b/sdp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-macros"
-version = "1.3.6"
+version = "1.3.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-test-macros/Cargo.toml
+++ b/sdp-test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-test-macros"
-version = "1.3.6"
+version = "1.3.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Description
- Reduce clutters in the logs by moving some logs to debug
- Add instructions on how to inject non-Deployment resource in the README

## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
