### PR TITLE
Ensure to carry over tags on Service User activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-common"
-version = "1.3.10"
+version = "1.3.11"
 dependencies = [
  "chrono",
  "const_format",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-identity-service"
-version = "1.3.10"
+version = "1.3.11"
 dependencies = [
  "async-trait",
  "clap",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "sdp-injector"
-version = "1.3.10"
+version = "1.3.11"
 dependencies = [
  "async-trait",
  "futures",
@@ -1763,11 +1763,11 @@ dependencies = [
 
 [[package]]
 name = "sdp-macros"
-version = "1.3.10"
+version = "1.3.11"
 
 [[package]]
 name = "sdp-test-macros"
-version = "1.3.10"
+version = "1.3.11"
 
 [[package]]
 name = "secrecy"

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.3.10"
+version: "1.3.11"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.10"
+appVersion: "1.3.11"

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.3.10"
+version: "1.3.11"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
-appVersion: "1.3.10"
+appVersion: "1.3.11"

--- a/sdp-common/Cargo.toml
+++ b/sdp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-common"
-version = "1.3.10"
+version = "1.3.11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-common/src/kubernetes.rs
+++ b/sdp-common/src/kubernetes.rs
@@ -68,7 +68,7 @@ impl Named for Pod {
                         }
                     }
                     None => self.metadata.name.as_ref().map(Clone::clone).unwrap_or({
-                        error!("Unable to find .metadata.name of Pod");
+                        debug!("Unable to find .metadata.name of Pod");
                         uuid::Uuid::new_v4().to_string()
                     }),
                 }

--- a/sdp-common/src/sdp/auth.rs
+++ b/sdp-common/src/sdp/auth.rs
@@ -51,6 +51,8 @@ pub struct SDPUser {
     pub id: String,
     pub name: String,
     pub labels: HashMap<String, String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
     #[serde(skip_deserializing)]
     pub password: Option<String>,
     pub disabled: bool,
@@ -67,6 +69,7 @@ impl SDPUser {
             name: name.unwrap_or(id.clone()),
             id,
             labels: HashMap::new(),
+            tags: vec![],
             password: Some(password.to_string()),
             disabled: disabled.unwrap_or(true),
             failed_login_attempts: None,
@@ -96,6 +99,7 @@ impl From<&ServiceUser> for SDPUser {
             id: name.clone(),
             name: name,
             labels: HashMap::new(),
+            tags: vec![],
             password: None,
             disabled: true,
             failed_login_attempts: None,

--- a/sdp-identity-service/Cargo.toml
+++ b/sdp-identity-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-identity-service"
-version = "1.3.10"
+version = "1.3.11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/src/identity_creator.rs
+++ b/sdp-identity-service/src/identity_creator.rs
@@ -478,6 +478,9 @@ impl IdentityCreator {
                     sdp_user.disabled = false;
                     sdp_user.labels = labels;
                     sdp_user.name = get_service_username(&cluster_id, &service_ns, &service_name);
+                    if let Ok(existing) = system.get_user(service_user.id.clone()).await {
+                        sdp_user.tags = existing.tags;
+                    }
                     let mut service_user = service_user.clone();
                     service_user.name = sdp_user.name.clone();
 

--- a/sdp-injector/Cargo.toml
+++ b/sdp-injector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-injector"
-version = "1.3.10"
+version = "1.3.11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-macros/Cargo.toml
+++ b/sdp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-macros"
-version = "1.3.10"
+version = "1.3.11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-test-macros/Cargo.toml
+++ b/sdp-test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-test-macros"
-version = "1.3.10"
+version = "1.3.11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Description
- Tags are not carried over when activating the Service User

## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
