### PR TITLE
Refactor the reconciliation logic by letting unknown Service User credential survive

### DIFF
--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.3.11"
+version: "1.3.12"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.11"
+appVersion: "1.3.12"

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for SDP Kubernetes Injector CRD
 type: application
 
 # Chart version should remain consistent with ../chart/Chart.yaml
-version: "1.3.11"
+version: "1.3.12"
 
 # Chart appVersion should be the same as ../chart/Chart.yaml
-appVersion: "1.3.11"
+appVersion: "1.3.12"

--- a/sdp-common/Cargo.toml
+++ b/sdp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-common"
-version = "1.3.11"
+version = "1.3.12"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/Cargo.toml
+++ b/sdp-identity-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-identity-service"
-version = "1.3.11"
+version = "1.3.12"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-identity-service/src/identity_manager.rs
+++ b/sdp-identity-service/src/identity_manager.rs
@@ -787,23 +787,27 @@ impl<'a> IdentityManagerService<ServiceCandidate, ServiceIdentity> for IdentityM
         let mut removed_service_identities: HashSet<String> = HashSet::new();
         info!("IdentityManager is ready");
 
-        // Here we do a basic cleanup of the current state
-        // 1. First we ask for deletion for all the ServiceIdentity instances that don't have a known
-        //    ServiceCandidate. This will eventually remove the ServiceUser associated
-        // 2. Now we remove all the known active ServiceUser instances that don't belong to any ServiceIdentity
-        // 3. Then we delete any ServiceIdentity instance that does not have a ServiceUser activated
-        // 4. Finally we unregister all device ids for current services that have unused clients:
-        //    Example: ns1_app1_XXXXX is active but we have device ids registered for ns1_app1_YYYYY and
-        //             ns1_app1_ZZZZZ. Then ns1_app1_YYYYY and ns1_app1_ZZZZZ will be unregistered.
+        info!(
+            "Reconciliation state: {} ServiceIdentities registered, {} known ServiceCandidates, {} activated ServiceUsers, {} deactivated ServiceUsers, {} missing ServiceCandidates",
+            self.service_credentials_provider.identities().len(),
+            self.existing_service_candidates.len(),
+            self.existing_activated_credentials.len(),
+            self.existing_deactivated_credentials.len(),
+            self.missing_service_candidates.len()
+        );
 
         info!(IdentityManagerProtocol::<ServiceCandidate, ServiceIdentity>::IdentityManagerDebug |("Syncing ServiceIdentity instances") => self.external_queue_tx);
 
-        // 1. Delete IdentityService instances with unknown ServiceCandidate
+        // 1. Delete ServiceIdentity instances with unknown ServiceCandidate
         info!("Searching for ServiceIdentities with unknown ServiceCandidate");
-        for service_identity in self
+        let extra = self
             .service_credentials_provider
-            .extra_service_identities(&self.existing_service_candidates)
-        {
+            .extra_service_identities(&self.existing_service_candidates);
+        info!(
+            "Found {} ServiceIdentities with unknown ServiceCandidate",
+            extra.len()
+        );
+        for service_identity in extra {
             let service_id = service_identity.service_id();
             info!(
                 "[{}] Found ServiceIdentity {} with unknown ServiceCandidate. Deleting it.",
@@ -830,10 +834,11 @@ impl<'a> IdentityManagerService<ServiceCandidate, ServiceIdentity> for IdentityM
 
         // 2. Delete ServiceUser instances that don't belong to any ServiceIdentity
         info!("Searching for orphaned ServiceUsers");
-        for sdp_user_name in self
+        let orphan_users = self
             .service_credentials_provider
-            .orphan_service_users(&self.existing_activated_credentials)
-        {
+            .orphan_service_users(&self.existing_activated_credentials);
+        info!("Found {} orphaned ServiceUsers", orphan_users.len());
+        for sdp_user_name in orphan_users {
             info!(
                 "SDPUser {} is active but not used by any ServiceIdentity, deleting it",
                 sdp_user_name
@@ -844,12 +849,16 @@ impl<'a> IdentityManagerService<ServiceCandidate, ServiceIdentity> for IdentityM
                 .expect("Error deleting orphaned SDPUser");
         }
 
-        // 3. Delete IdentityService instances holding not active credentials
+        // 3. Delete ServiceIdentity instances holding deactivated credentials
         info!("Searching for orphaned ServiceIdentities");
-        for service_identity in self
+        let orphan_identities = self
             .service_credentials_provider
-            .orphan_service_identities(&self.existing_deactivated_credentials)
-        {
+            .orphan_service_identities(&self.existing_deactivated_credentials);
+        info!(
+            "Found {} ServiceIdentities with deactivated ServiceUsers",
+            orphan_identities.len()
+        );
+        for service_identity in orphan_identities {
             let service_id = service_identity.service_id();
             if !removed_service_identities.contains(&service_id) {
                 info!(
@@ -876,6 +885,11 @@ impl<'a> IdentityManagerService<ServiceCandidate, ServiceIdentity> for IdentityM
             }
         }
 
+        info!(
+            "Reconciliation complete: {} ServiceIdentities deleted",
+            removed_service_identities.len()
+        );
+
         // Reconcile sdp_user device ids registered for active users that have a ServiceIdentity
         self.identity_creator_queue
             .send(IdentityCreatorProtocol::ReconcileSDPUsers(
@@ -890,6 +904,10 @@ impl<'a> IdentityManagerService<ServiceCandidate, ServiceIdentity> for IdentityM
             .expect("Error reconciliating SDP users");
 
         // Request ServiceIdentity for candidates that dont have it
+        info!(
+            "Requesting ServiceIdentity for {} missing ServiceCandidates",
+            self.missing_service_candidates.len()
+        );
         for (service_candidate_id, service_candidate) in &self.missing_service_candidates {
             info!(
                 "[{}] Requesting missing ServiceCandidate {}",

--- a/sdp-identity-service/src/identity_manager.rs
+++ b/sdp-identity-service/src/identity_manager.rs
@@ -72,14 +72,14 @@ trait ServiceCredentialProvider: ServiceUserPool {
             .collect()
     }
 
-    /// ServiceIdentity instances that don't have active ServiceUsers
+    /// ServiceIdentity instances that have deactivated ServiceUsers
     fn orphan_service_identities<'a>(
         &self,
-        activated_service_users: &'a HashSet<String>,
+        deactivated_service_users: &'a HashSet<String>,
     ) -> Vec<&Self::To> {
         self.identities()
             .iter()
-            .filter(|i| !activated_service_users.contains(&i.credentials().id))
+            .filter(|i| deactivated_service_users.contains(&i.credentials().id))
             .map(|i| *i)
             .collect()
     }
@@ -848,7 +848,7 @@ impl<'a> IdentityManagerService<ServiceCandidate, ServiceIdentity> for IdentityM
         info!("Searching for orphaned ServiceIdentities");
         for service_identity in self
             .service_credentials_provider
-            .orphan_service_identities(&self.existing_activated_credentials)
+            .orphan_service_identities(&self.existing_deactivated_credentials)
         {
             let service_id = service_identity.service_id();
             if !removed_service_identities.contains(&service_id) {
@@ -1472,15 +1472,26 @@ mod tests {
     #[test]
     fn test_identity_manager_service_credentials_provider_orphan_identities() {
         // orphan_service_identities computes the list of service identities holding
-        // ServiceUsers that are not active anymore
+        // ServiceUsers that are deactivated
         test_identity_manager_service_credentials_provider! {
             im => {
                 let mut identities = im.identities();
                 identities.sort_by(|a, b| a.name_any().as_str().partial_cmp(b.name_any().as_str()).unwrap());
 
-                // 4 service identities registered none active service users,
+                // no deactivated service users, no orphans
                 let xs = service_identities_to_tuple(
                     im.orphan_service_identities(&HashSet::new()));
+                assert_eq!(xs.len(), 0);
+                assert_eq!(xs, vec![]);
+
+                // all 4 service users deactivated, all 4 identities are orphans
+                let xs = service_identities_to_tuple(
+                    im.orphan_service_identities(&HashSet::from([
+                        identities[0].credentials().id.clone(),
+                        identities[1].credentials().id.clone(),
+                        identities[2].credentials().id.clone(),
+                        identities[3].credentials().id.clone(),
+                    ])));
                 assert_eq!(xs.len(), 4);
                 assert_eq!(xs, vec![
                     ("ns1", "srv1", "service_user_id1"),
@@ -1489,22 +1500,11 @@ mod tests {
                     ("ns4", "srv4", "service_user_id4"),
                 ]);
 
-                // 4 service identities registered 4 active service users,
+                // 2 of 4 service users deactivated, 2 identities are orphans
                 let xs = service_identities_to_tuple(
                     im.orphan_service_identities(&HashSet::from([
-                        identities[0].credentials().id.clone(),
-                        identities[1].credentials().id.clone(),
-                        identities[2].credentials().id.clone(),
-                        identities[3].credentials().id.clone(),
-                    ])));
-                assert_eq!(xs.len(), 0);
-                assert_eq!(xs, vec![]);
-
-                // 4 service identities registered 2 active service users,
-                let xs = service_identities_to_tuple(
-                    im.orphan_service_identities(&HashSet::from([
-                        identities[1].credentials().id.clone(), // service_user2
-                        identities[3].credentials().id.clone(), // service_user4
+                        identities[0].credentials().id.clone(), // service_user1
+                        identities[2].credentials().id.clone(), // service_user3
                     ])));
                 assert_eq!(xs.len(), 2);
                 assert_eq!(xs, vec![
@@ -1512,13 +1512,9 @@ mod tests {
                     ("ns3", "srv3", "service_user_id3"),
                 ]);
 
-                // 4 service identities registered 5 active service users,
+                // deactivated set contains an id not belonging to any identity, no extra orphans
                 let xs = service_identities_to_tuple(
                     im.orphan_service_identities(&HashSet::from([
-                        identities[0].credentials().id.clone(),
-                        identities[1].credentials().id.clone(),
-                        identities[2].credentials().id.clone(),
-                        identities[3].credentials().id.clone(),
                         service_identity!(5).credentials().id.clone()
                     ])));
                 assert_eq!(xs.len(), 0);

--- a/sdp-injector/Cargo.toml
+++ b/sdp-injector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-injector"
-version = "1.3.11"
+version = "1.3.12"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-macros/Cargo.toml
+++ b/sdp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-macros"
-version = "1.3.11"
+version = "1.3.12"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdp-test-macros/Cargo.toml
+++ b/sdp-test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdp-test-macros"
-version = "1.3.11"
+version = "1.3.12"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Description

```

  ┌─────────────────────────┬───────────────────────────────────┬────────────────────────────────────┐
  │        Scenario         │          Current logic            │          Proposed logic            │
  │                         │       (!activated.contains)       │       (deactivated.contains)       │
  ├─────────────────────────┼───────────────────────────────────┼────────────────────────────────────┤
  │ Credential is activated │ Not returned (correct)            │ Not returned (correct)             │
  ├─────────────────────────┼───────────────────────────────────┼────────────────────────────────────┤
  │ Credential is           │ Returned → deleted                │ Returned → deleted                 │
  │ deactivated             │                                   │                                    │
  ├─────────────────────────┼───────────────────────────────────┼────────────────────────────────────┤
  │ Credential not seen at  │ Returned → deleted                │ Not returned → survives            │
  │ all                     │                                   │                                    │
  └─────────────────────────┴───────────────────────────────────┴────────────────────────────────────┘

```

## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/chart/Chart.yaml](../k8s/chart/Chart.yaml)
